### PR TITLE
[Fix] Search by name in company members

### DIFF
--- a/apps/api/app/services/Resources/Company/CompanyMemberService.php
+++ b/apps/api/app/services/Resources/Company/CompanyMemberService.php
@@ -22,8 +22,8 @@ class CompanyMemberService
                 $builder
                     ->whereHas('member', function (Builder $q) use ($filters) {
                         $q->where(
-                            DB::raw('CONCAT(users.first_name, " ", users.last_name)'),
-                            'LIKE',
+                            DB::raw("CONCAT(users.first_name, ' ', users.last_name)"),
+                            'ILIKE',
                             $filters->get('memberName') . '%'
                         );
                     })
@@ -39,8 +39,8 @@ class CompanyMemberService
                 $builder
                     ->whereHas('invitedBy', function (Builder $q) use ($filters) {
                         $q->where(
-                            DB::raw('CONCAT(users.first_name, " ", users.last_name)'),
-                            'LIKE',
+                            DB::raw("CONCAT(users.first_name, ' ', users.last_name)"),
+                            'ILIKE',
                             $filters->get('invitedByName') . '%'
                         );
                     });


### PR DESCRIPTION
- changed `"` to `'`
- using `ILIKE` now instead of `LIKE`
- resolves #11