### PR TITLE
[Fix] search by creator on sessions page

### DIFF
--- a/apps/api/app/services/Resources/SessionService.php
+++ b/apps/api/app/services/Resources/SessionService.php
@@ -41,8 +41,8 @@ class SessionService
         if ($filters->has('createdByName')) {
             $sessions->whereHas('createdBy', function (Builder $builder) use ($filters) {
                 $builder->where(
-                    DB::raw('CONCAT(users.first_name, " ", users.last_name)'),
-                    'LIKE',
+                    DB::raw("CONCAT(users.first_name, ' ', users.last_name)"),
+                    'ILIKE',
                     $filters->get('createdByName') . '%'
                 );
             });


### PR DESCRIPTION
- using `'` instead of `"`
	- this was introduced when we switched to postgres
- using `ILIKE` instead of `LIKE`
- closes #20 