### PR TITLE
[v0.2.1]

### DIFF
--- a/apps/api/app/Http/Resources/Resources/CompanyResource.php
+++ b/apps/api/app/Http/Resources/Resources/CompanyResource.php
@@ -20,7 +20,6 @@ class CompanyResource extends JsonResource
             'id' => $this->id,
             'name' => $this->name,
             'createdAt' => $this->created_at,
-            'subscription' => $this->subscription(),
         ])
             ->when(!config('devqaly.isSelfHosting'), function (Collection $collection) {
                 $subscription = $this->subscription();

--- a/apps/webapp/src/layouts/ProjectLayout.vue
+++ b/apps/webapp/src/layouts/ProjectLayout.vue
@@ -152,7 +152,11 @@ function shouldShowSubscriptionWarning(): boolean {
   assertsIsCompanyCodec(appStore.activeCompany)
 
   // If no subscription is present, we are assuming the user is in free plan.
-  if (appStore.activeCompany.subscription === null) return true
+  if (
+    appStore.activeCompany.subscription === null ||
+    appStore.activeCompany.subscription === undefined
+  )
+    return true
 
   return !isActiveSubscription(appStore.activeCompany.subscription.status)
 }

--- a/apps/webapp/src/services/api/resources/company/codec.ts
+++ b/apps/webapp/src/services/api/resources/company/codec.ts
@@ -4,5 +4,5 @@ import type { SubscriptionCodec } from '@/services/api/resources/subscription/co
 export interface CompanyCodec {
   id: ResourceID
   name: string
-  subscription: SubscriptionCodec | null
+  subscription?: SubscriptionCodec | null
 }


### PR DESCRIPTION
- fixed a bug where we were accesing `subscription` on backend on self hosting instances