### PR TITLE
Add custom event

### DIFF
--- a/apps/api/app/Http/Requests/Resources/Session/Event/CreateSessionEventRequest.php
+++ b/apps/api/app/Http/Requests/Resources/Session/Event/CreateSessionEventRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\Resources\Session\Event;
 
+use App\Models\Session\Event\EventCustomEvent;
 use App\Models\Session\Event\EventDatabaseTransaction;
 use App\Models\Session\Event\EventElementClick;
 use App\Models\Session\Event\EventElementScroll;
@@ -51,6 +52,7 @@ class CreateSessionEventRequest extends FormRequest
                 EventElementScroll::class,
                 EventResizeScreen::class,
                 EventDatabaseTransaction::class,
+                EventCustomEvent::class,
                 EventLog::class,
             ]),
         ]], $this->request->all());

--- a/apps/api/app/Models/Session/Event/EventCustomEvent.php
+++ b/apps/api/app/Models/Session/Event/EventCustomEvent.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models\Session\Event;
+
+use App\Models\Session\Event;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphOne;
+
+class EventCustomEvent extends Model
+{
+    use HasFactory, HasUuids;
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'payload',
+        'name',
+    ];
+
+    protected $casts = [
+        'payload' => 'array'
+    ];
+
+    public function event(): MorphOne
+    {
+        return $this->morphOne(Event::class, 'event');
+    }
+}

--- a/apps/api/app/services/Resources/Event/Types/EventTypeCustomEventService.php
+++ b/apps/api/app/services/Resources/Event/Types/EventTypeCustomEventService.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\services\Resources\Event\Types;
+
+use App\Models\Session\Event;
+use App\Models\Session\Event\EventCustomEvent;
+use App\Models\Session\Session;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+class EventTypeCustomEventService extends BaseEventTypeService implements EventTypeServiceInterface
+{
+
+    public function toArrayResource($resource): array
+    {
+        return [
+            'id' => $resource->id,
+            'name' => $resource->name,
+            'payload' => $resource->payload,
+        ];
+    }
+
+    public function create(Collection $data, Session $session): void
+    {
+        try {
+            DB::beginTransaction();
+
+            $customEvent = EventCustomEvent::create([
+                    'payload' => $data->get('payload'),
+                    'name' => $data->get('name'),
+                ]);
+
+            Event::create([
+                'source' => $data->get('source'),
+                'session_id' => $session->id,
+                'event_type' => Event\EventCustomEvent::class,
+                'event_id' => $customEvent->id,
+                'client_utc_event_created_at' => $data->get('clientUtcEventCreatedAt')
+            ]);
+
+            DB::commit();
+        } catch (\Exception $e) {
+            Log::error('There was an error creating EventDatabaseTransaction event: ' . $e->getMessage());
+
+            DB::rollBack();
+        }
+    }
+
+    public function createValidationRules(): array
+    {
+        return $this->baseValidationRules([
+            'payload' => 'json',
+            'name' => 'required|string|max:255|min:1',
+        ]);
+    }
+}

--- a/apps/api/app/services/Resources/Event/Types/EventTypeFactory.php
+++ b/apps/api/app/services/Resources/Event/Types/EventTypeFactory.php
@@ -2,6 +2,7 @@
 
 namespace App\services\Resources\Event\Types;
 
+use App\Models\Session\Event\EventCustomEvent;
 use App\Models\Session\Event\EventDatabaseTransaction;
 use App\Models\Session\Event\EventElementClick;
 use App\Models\Session\Event\EventElementScroll;
@@ -22,6 +23,7 @@ class EventTypeFactory
             EventResizeScreen::class => new EventTypeResizeScreenService(),
             EventDatabaseTransaction::class => new EventTypeDatabaseTransactionService(),
             EventLog::class => new EventTypeLogService(),
+            EventCustomEvent::class => new EventTypeCustomEventService(),
             default => throw new \Exception('This event type was not implemented yet: ' . $type),
         };
     }

--- a/apps/api/database/factories/Session/Event/EventCustomEventFactory.php
+++ b/apps/api/database/factories/Session/Event/EventCustomEventFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories\Session\Event;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Session\Event\EventCustomEvent>
+ */
+class EventCustomEventFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/apps/api/database/migrations/2023_11_04_130825_create_event_custom_events_table.php
+++ b/apps/api/database/migrations/2023_11_04_130825_create_event_custom_events_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('event_custom_events', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('name');
+            $table->json('payload')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('event_custom_events');
+    }
+};

--- a/apps/api/database/seeders/EventCustomEventSeeder.php
+++ b/apps/api/database/seeders/EventCustomEventSeeder.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class EventCustomEventSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        //
+    }
+}

--- a/apps/webapp/src/components/pages/projects/ProjectSessionView/EventTabs/ActiveEvent/ActiveEventDetail.ts
+++ b/apps/webapp/src/components/pages/projects/ProjectSessionView/EventTabs/ActiveEvent/ActiveEventDetail.ts
@@ -9,6 +9,7 @@ import NetworkEventDetails from '@/components/pages/projects/ProjectSessionView/
 import ResizeScreenDetails from '@/components/pages/projects/ProjectSessionView/EventTabs/ActiveEvent/types/ResizeScreenDetails.vue'
 import ScrollTabDetails from '@/components/pages/projects/ProjectSessionView/EventTabs/ActiveEvent/types/ScrollTabDetails.vue'
 import LogEventDetails from '@/components/pages/projects/ProjectSessionView/EventTabs/ActiveEvent/types/LogEventDetails.vue'
+import CustomEvent from '@/components/pages/projects/ProjectSessionView/EventTabs/ActiveEvent/types/CustomEvent.vue'
 
 const ACTIVE_EVENT_DETAILS: Record<EventTypesEnum, ReturnType<typeof defineComponent>> = {
   [EventTypesEnum.CHANGED_URL]: ChangeUrlDetails,
@@ -17,7 +18,8 @@ const ACTIVE_EVENT_DETAILS: Record<EventTypesEnum, ReturnType<typeof defineCompo
   [EventTypesEnum.NETWORK_REQUEST]: NetworkEventDetails,
   [EventTypesEnum.RESIZE_SCREEN]: ResizeScreenDetails,
   [EventTypesEnum.SCROLL]: ScrollTabDetails,
-  [EventTypesEnum.LOG]: LogEventDetails
+  [EventTypesEnum.LOG]: LogEventDetails,
+  [EventTypesEnum.CUSTOM_EVENT]: CustomEvent
 } as const
 
 export const ActiveEventDetail = defineComponent({

--- a/apps/webapp/src/components/pages/projects/ProjectSessionView/EventTabs/ActiveEvent/types/CustomEvent.vue
+++ b/apps/webapp/src/components/pages/projects/ProjectSessionView/EventTabs/ActiveEvent/types/CustomEvent.vue
@@ -1,0 +1,45 @@
+<template>
+  <BaseEventDetails
+    data-cy="project-session-view__active-event"
+    data-event-type="change-url"
+  >
+    <div class="text-gray-500">Source</div>
+
+    <DCopyble :content="props.event.source">
+      <div
+        class="font-medium"
+        data-cy="project-session-view__active-event--url-change-source"
+        v-text="props.event.source"
+      />
+    </DCopyble>
+
+    <div class="text-gray-500 mt-2">Name</div>
+    <DCopyble :content="props.event.event.name">
+      <div
+        style="word-break: break-all"
+        data-cy="project-session-view__active-event--url-change-url"
+        class="font-medium"
+        v-text="props.event.event.name"
+      />
+    </DCopyble>
+
+    <div class="text-gray-500 mt-2">Payload</div>
+    <DCopyble :content="props.event.event.payload.toString()">
+      <div
+        style="word-break: break-all"
+        data-cy="project-session-view__active-event--url-change-url"
+        class="font-medium"
+        v-text="props.event.event.payload"
+      />
+    </DCopyble>
+  </BaseEventDetails>
+</template>
+
+<script setup lang="ts">
+import BaseEventDetails from '@/components/pages/projects/ProjectSessionView/EventTabs/ActiveEvent/BaseEventDetails.vue'
+import type { CustomEvent, UrlChanged } from '@/services/api/resources/session/events/codec'
+import type { Props } from '@/components/pages/projects/ProjectSessionView/EventTabs/ActiveEvent/common'
+import DCopyble from '@/components/DCopyble.vue'
+
+const props = defineProps<Props<CustomEvent>>()
+</script>

--- a/apps/webapp/src/components/pages/projects/ProjectSessionView/EventTabs/EventsSection.ts
+++ b/apps/webapp/src/components/pages/projects/ProjectSessionView/EventTabs/EventsSection.ts
@@ -11,6 +11,7 @@ import ResizeScreenTab from '@/components/pages/projects/ProjectSessionView/Even
 import DatabaseTransactionTab from '@/components/pages/projects/ProjectSessionView/EventTabs/types/DatabaseTransactionTab.vue'
 import { ActiveEventDetail } from '@/components/pages/projects/ProjectSessionView/EventTabs/ActiveEvent/ActiveEventDetail'
 import LogEventTab from '@/components/pages/projects/ProjectSessionView/EventTabs/types/LogEventTab.vue'
+import CustomEventTab from '@/components/pages/projects/ProjectSessionView/EventTabs/types/CustomEventTab.vue'
 
 const COMPONENTS: Record<EventTypesEnum, ReturnType<typeof defineComponent>> = {
   [EventTypesEnum.NETWORK_REQUEST]: NetworkEventTab,
@@ -19,7 +20,8 @@ const COMPONENTS: Record<EventTypesEnum, ReturnType<typeof defineComponent>> = {
   [EventTypesEnum.SCROLL]: ScrollTab,
   [EventTypesEnum.RESIZE_SCREEN]: ResizeScreenTab,
   [EventTypesEnum.DATABASE_TRANSACTION]: DatabaseTransactionTab,
-  [EventTypesEnum.LOG]: LogEventTab
+  [EventTypesEnum.LOG]: LogEventTab,
+  [EventTypesEnum.CUSTOM_EVENT]: CustomEventTab
 }
 
 const TABS_TITLE: Record<EventTypesEnum, string> = {
@@ -29,7 +31,8 @@ const TABS_TITLE: Record<EventTypesEnum, string> = {
   [EventTypesEnum.SCROLL]: 'Scroll',
   [EventTypesEnum.RESIZE_SCREEN]: 'Resized Screen',
   [EventTypesEnum.DATABASE_TRANSACTION]: 'Database Transaction',
-  [EventTypesEnum.LOG]: 'Logs'
+  [EventTypesEnum.LOG]: 'Logs',
+  [EventTypesEnum.CUSTOM_EVENT]: 'Custom Events'
 }
 
 const tabs: {
@@ -44,6 +47,7 @@ const tabs: {
     | 'resizedScreenEvents'
     | 'databaseTransactionEvents'
     | 'logEvents'
+    | 'customEvents'
 }[] = [
   {
     type: EventTypesEnum.NETWORK_REQUEST,
@@ -86,6 +90,12 @@ const tabs: {
     'data-cy': 'project-session-view__activate-log-events-tab',
     icon: 'pi pi-paperclip',
     storeGetter: 'logEvents'
+  },
+  {
+    type: EventTypesEnum.CUSTOM_EVENT,
+    'data-cy': 'project-session-view__activate-custom-events-tab',
+    icon: 'pi pi-paperclip',
+    storeGetter: 'customEvents'
   }
 ]
 

--- a/apps/webapp/src/components/pages/projects/ProjectSessionView/EventTabs/types/CustomEventTab.vue
+++ b/apps/webapp/src/components/pages/projects/ProjectSessionView/EventTabs/types/CustomEventTab.vue
@@ -1,0 +1,26 @@
+<template>
+  <div>
+    <div
+      v-for="request in sessionStore.customEvents"
+      :key="request.id"
+    >
+      <CustomEvent
+        :session="sessionStore.activeSession"
+        :event="request"
+        @see:details="onSeeMoreDetails"
+      />
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { useSessionsStore } from '@/stores/sessions'
+import type { EventCodec } from '@/services/api/resources/session/events/codec'
+import CustomEvent from '@/components/resources/events/listEvent/types/CustomEvent.vue'
+
+const sessionStore = useSessionsStore()
+
+function onSeeMoreDetails(event: EventCodec) {
+  sessionStore.activeEventDetails = event
+}
+</script>

--- a/apps/webapp/src/components/resources/events/listEvent/ListEvents.ts
+++ b/apps/webapp/src/components/resources/events/listEvent/ListEvents.ts
@@ -12,6 +12,7 @@ import ScrollEvent from '@/components/resources/events/listEvent/types/ScrollEve
 import ResizeScreenEvent from '@/components/resources/events/listEvent/types/ResizeScreenEvent.vue'
 import DatabaseTransactionEvent from '@/components/resources/events/listEvent/types/DatabaseTransactionEvent.vue'
 import LogEvent from '@/components/resources/events/listEvent/types/LogEvent.vue'
+import CustomEvent from '@/components/resources/events/listEvent/types/CustomEvent.vue'
 
 const EventsComponents: Record<EventTypesEnum, ReturnType<typeof defineComponent>> = {
   [EventTypesEnum.NETWORK_REQUEST]: NetworkEvent,
@@ -20,7 +21,8 @@ const EventsComponents: Record<EventTypesEnum, ReturnType<typeof defineComponent
   [EventTypesEnum.SCROLL]: ScrollEvent,
   [EventTypesEnum.RESIZE_SCREEN]: ResizeScreenEvent,
   [EventTypesEnum.DATABASE_TRANSACTION]: DatabaseTransactionEvent,
-  [EventTypesEnum.LOG]: LogEvent
+  [EventTypesEnum.LOG]: LogEvent,
+  [EventTypesEnum.CUSTOM_EVENT]: CustomEvent
 } as const
 
 export const ListEvents = defineComponent({

--- a/apps/webapp/src/components/resources/events/listEvent/types/CustomEvent.vue
+++ b/apps/webapp/src/components/resources/events/listEvent/types/CustomEvent.vue
@@ -1,0 +1,30 @@
+<template>
+  <BaseEvent
+    data-cy="list-event__event"
+    data-event-type="log"
+    :session="props.session"
+    :event="props.event"
+    @see:details="onSeeDetails"
+  >
+    {{ props.event.event.name }}
+  </BaseEvent>
+</template>
+
+<script lang="ts" setup>
+import type { CustomEvent } from '@/services/api/resources/session/events/codec'
+import type { SessionCodec } from '@/services/api/resources/session/codec'
+import BaseEvent from '@/components/resources/events/listEvent/BaseEvent.vue'
+import type { EmitEventsDefinitions } from '@/components/resources/events/listEvent/types/useEventTypes'
+import type { EventCodec } from '@/services/api/resources/session/events/codec'
+
+const props = defineProps<{
+  event: CustomEvent
+  session: SessionCodec
+}>()
+
+const emit = defineEmits<EmitEventsDefinitions>()
+
+function onSeeDetails(event: EventCodec) {
+  emit('see:details', event)
+}
+</script>

--- a/apps/webapp/src/services/api/resources/session/events/codec.ts
+++ b/apps/webapp/src/services/api/resources/session/events/codec.ts
@@ -64,6 +64,12 @@ export interface BaseLogEvent {
   requestId: UUID | null
 }
 
+export interface BaseCustomEvent {
+  id: ResourceID
+  name: string
+  payload: object
+}
+
 export type NetworkRequestEvent = BaseEventCodec<BaseNetworkRequestEvent>
 export type UrlChanged = BaseEventCodec<BaseChangedUrlEvent>
 export type ElementClick = BaseEventCodec<BaseElementClick>
@@ -71,6 +77,7 @@ export type ScrollEvent = BaseEventCodec<BaseScroll>
 export type ResizeScreenEvent = BaseEventCodec<BaseResizeScreen>
 export type DatabaseTransactionEvent = BaseEventCodec<BaseDatabaseTransaction>
 export type LogEvent = BaseEventCodec<BaseLogEvent>
+export type CustomEvent = BaseEventCodec<BaseCustomEvent>
 
 export type EventCodec =
   | NetworkRequestEvent
@@ -80,3 +87,4 @@ export type EventCodec =
   | ResizeScreenEvent
   | DatabaseTransactionEvent
   | LogEvent
+  | CustomEvent

--- a/apps/webapp/src/services/api/resources/session/events/constants.ts
+++ b/apps/webapp/src/services/api/resources/session/events/constants.ts
@@ -5,7 +5,8 @@ export enum EventTypesEnum {
   SCROLL = 'App\\Models\\Session\\Event\\EventElementScroll',
   RESIZE_SCREEN = 'App\\Models\\Session\\Event\\EventResizeScreen',
   DATABASE_TRANSACTION = 'App\\Models\\Session\\Event\\EventDatabaseTransaction',
-  LOG = 'App\\Models\\Session\\Event\\EventLog'
+  LOG = 'App\\Models\\Session\\Event\\EventLog',
+  CUSTOM_EVENT = 'App\\Models\\Session\\Event\\EventCustomEvent'
 }
 
 export enum LOG_LEVEL {

--- a/apps/webapp/src/stores/sessions.ts
+++ b/apps/webapp/src/stores/sessions.ts
@@ -5,6 +5,7 @@ import { getSession } from '@/services/api/resources/session/actions'
 import type { PaginatableRecord } from '@/services/api'
 import { emptyPagination } from '@/services/api'
 import type {
+  CustomEvent,
   DatabaseTransactionEvent,
   ElementClick,
   EventCodec,
@@ -117,7 +118,16 @@ export const useSessionsStore = defineStore('sessionsStore', {
           EventTypesEnum.LOG,
           state.activeSession.createdAt
         )
-      ) as LogEvent[]
+      ) as LogEvent[],
+    customEvents: (state: SessionStoreState) =>
+      state.activeSessionEventsRequest.data.filter((e) =>
+        filterEventsUntilVideoCurrentTime(
+          e,
+          state.currentVideoDuration,
+          EventTypesEnum.CUSTOM_EVENT,
+          state.activeSession.createdAt
+        )
+      ) as CustomEvent[]
   },
   actions: {
     async getActiveSession(sessionId: string) {


### PR DESCRIPTION
# Introduction

Some of our clients needs to be able to create custom events that are not offered by Devqaly.

Imagine for example an application that simply manipulates data in memory and nothing is sent to backend servers. The whole data manipulation is made directly in the frontend. The sort of apps (and scenarios) needs a way to send events to Devqaly's backend server since we are not tracking these data manipulations that are extremely important to debug edge cases.

# Solution

Our proposed solution is to allow the SDKs to create custom events. The function signature would look like:

```ts
createCustomEvent(eventName: string, payload: object | string): Promise<null>
```

The usage of the function would look like:

```ts
import { DevqalySDK } from '@devqaly/browser'

const devqalySDK = new DevqalySDK({
  projectKey: 'xxxxx',
})

devqalySDK.createCustomEvent('event-name', {
  oldData: { firstName: 'Joao' },
  newData: { firstName: 'Bruno' }
})
```

If this method is called when a session is not being recorded, then it would be completely ignored and nothing would be sent to Devqaly's backend.

This would allow any app to create events that are not supported by Devqaly, allowing them to track much more complex scenarios that Devqaly was not intended to track initially.

