### PR TITLE
Feature/add environment to session

### DIFF
--- a/apps/api/app/Http/Requests/Resources/Project/Session/CreateSessionRequest.php
+++ b/apps/api/app/Http/Requests/Resources/Project/Session/CreateSessionRequest.php
@@ -33,7 +33,8 @@ class CreateSessionRequest extends FormRequest
             'platformName' => 'required|string|max:255',
             'version' => 'required|string|max:255',
             'windowWidth' => 'required|integer|min:1|max:65535',
-            'windowHeight' => 'required|integer|min:1|max:65535'
+            'windowHeight' => 'required|integer|min:1|max:65535',
+            'environment' => 'string|max:50'
         ];
     }
 }

--- a/apps/api/app/Http/Resources/Resources/SessionResource.php
+++ b/apps/api/app/Http/Resources/Resources/SessionResource.php
@@ -16,6 +16,7 @@ class SessionResource extends JsonResource
         return [
             'id' => $this->id,
             'os' => $this->os,
+            'environment' => $this->environment,
             'platformName' => $this->platform_name,
             'version' => $this->version,
             'videoStatus' => $this->video_status,

--- a/apps/api/app/Models/Session/Session.php
+++ b/apps/api/app/Models/Session/Session.php
@@ -33,6 +33,7 @@ class Session extends Model
         'video_size_in_megabytes',
         'window_height',
         'window_width',
+        'environment'
     ];
 
     protected $casts = [

--- a/apps/api/app/services/Resources/SessionService.php
+++ b/apps/api/app/services/Resources/SessionService.php
@@ -27,6 +27,7 @@ class SessionService
             'window_height' => $data->get('windowHeight'),
             'project_id' => $project->id,
             'created_by_id' => $user?->id,
+            'environment' => $data->get('environment'),
         ]);
 
         if ($this->shouldDeletePastSessions($project)) {

--- a/apps/api/database/factories/Session/SessionFactory.php
+++ b/apps/api/database/factories/Session/SessionFactory.php
@@ -59,9 +59,16 @@ class SessionFactory extends Factory
             ...self::WINDOW_HEIGHTS['16:10'],
         ]);
 
+        $environment = $this->faker->randomElement([
+            'production',
+            'local',
+            'staging'
+        ]);
+
         return [
             'created_by_id' => User::factory(),
             'project_id' => Project::factory(),
+            'environment' => $environment,
             'window_width' => $windowDimensions[0],
             'window_height' => $windowDimensions[1],
             'os' => $this->faker->randomElement(self::OPERATING_SYSTEMS),

--- a/apps/api/database/migrations/2023_11_20_161530_add_environment_to_sessions_table.php
+++ b/apps/api/database/migrations/2023_11_20_161530_add_environment_to_sessions_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('sessions', function (Blueprint $table) {
+            $table->string('environment', 50)->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('sessions', function (Blueprint $table) {
+            $table->dropColumn('environment');
+        });
+    }
+};

--- a/apps/api/tests/Feature/Http/Controllers/Resources/ProjectSessionControllerTest.php
+++ b/apps/api/tests/Feature/Http/Controllers/Resources/ProjectSessionControllerTest.php
@@ -65,6 +65,14 @@ class ProjectSessionControllerTest extends TestCase
             ->assertJsonPath('data.windowHeight', $sessionPayload['windowHeight']);
 
         $this->assertDatabaseCount((new Session())->getTable(), 1);
+        $this->assertDatabaseHas((new Session())->getTable(), [
+            'environment' => $sessionPayload['environment'],
+            'os' => $sessionPayload['os'],
+            'platform_name' => $sessionPayload['platformName'],
+            'version' => $sessionPayload['version'],
+            'window_width' => $sessionPayload['windowWidth'],
+            'window_height' => $sessionPayload['windowHeight'],
+        ]);
     }
 
     public function test_session_returns_correct_maximum_session_length_for_company_with_enterprise(): void
@@ -238,12 +246,15 @@ class ProjectSessionControllerTest extends TestCase
             ...SessionFactory::WINDOW_HEIGHTS['16:10'],
         ]);
 
+        $environment = $this->faker->randomElement(['production', 'staging', 'local', 'development']);
+
         return [
             'os' => $this->faker->randomElement(SessionFactory::OPERATING_SYSTEMS),
             'platformName' => $this->faker->randomElement(SessionFactory::PLATFORM_NAMES),
             'version' => $this->faker->numberBetween(100, 200) . '.0.0',
             'windowWidth' => $windowDimensions[0],
-            'windowHeight' => $windowDimensions[1]
+            'windowHeight' => $windowDimensions[1],
+            'environment' => $environment
         ];
     }
 }

--- a/apps/api/tests/Feature/Http/Controllers/Resources/ProjectSessionControllerTest.php
+++ b/apps/api/tests/Feature/Http/Controllers/Resources/ProjectSessionControllerTest.php
@@ -59,6 +59,7 @@ class ProjectSessionControllerTest extends TestCase
             ]), $sessionPayload)
             ->assertCreated()
             ->assertJsonPath('data.os', $sessionPayload['os'])
+            ->assertJsonPath('data.environment', $sessionPayload['environment'])
             ->assertJsonPath('data.platformName', $sessionPayload['platformName'])
             ->assertJsonPath('data.version', $sessionPayload['version'])
             ->assertJsonPath('data.windowWidth', $sessionPayload['windowWidth'])

--- a/apps/webapp/src/components/pages/projects/ProjectSessionView/SessionSummary.vue
+++ b/apps/webapp/src/components/pages/projects/ProjectSessionView/SessionSummary.vue
@@ -33,6 +33,21 @@
     </div>
 
     <div class="mt-3">
+      <div class="text-gray-500">Environment</div>
+      <div
+        class="font-medium"
+        data-cy="project-session-view__environment"
+        v-if="!fetchingSession"
+        v-text="sessionStore.activeSession.environment"
+      />
+      <Skeleton
+        height="17px"
+        width="60px"
+        v-if="fetchingSession"
+      />
+    </div>
+
+    <div class="mt-3">
       <div class="text-gray-500">Version</div>
       <div
         class="font-medium"

--- a/apps/webapp/src/main.ts
+++ b/apps/webapp/src/main.ts
@@ -43,6 +43,7 @@ import TabView from 'primevue/tabview'
 import TabPanel from 'primevue/tabpanel'
 import Sidebar from 'primevue/sidebar'
 import ConfirmDialog from 'primevue/confirmdialog'
+import Tag from 'primevue/tag'
 
 export const app = createApp(App)
 
@@ -88,5 +89,6 @@ app.component(TabView.name, TabView)
 app.component(TabPanel.name, TabPanel)
 app.component(Sidebar.name, Sidebar)
 app.component(ConfirmDialog.name, ConfirmDialog)
+app.component(Tag.name, Tag)
 
 app.mount('#app')

--- a/apps/webapp/src/services/api/resources/session/codec.ts
+++ b/apps/webapp/src/services/api/resources/session/codec.ts
@@ -5,6 +5,7 @@ import type { ProjectCodec } from '@/services/api/resources/project/codec'
 
 export interface SessionCodec {
   id: ResourceID
+  environment: 'staging' | 'local' | string
   endedVideoConversionAt: DateTime | null
   os: string | null
   windowHeight: number

--- a/apps/webapp/src/services/factories/sessionsFactory.ts
+++ b/apps/webapp/src/services/factories/sessionsFactory.ts
@@ -3,6 +3,7 @@ import { SessionVideoStatusEnum } from '@/services/api/resources/session/constan
 
 export const sessionsCodecFactory = (): SessionCodec => ({
   id: '',
+  environment: 'staging',
   endedVideoConversionAt: null,
   windowWidth: 0,
   windowHeight: 0,

--- a/apps/webapp/src/views/projects/ProjectSessionsView.vue
+++ b/apps/webapp/src/views/projects/ProjectSessionsView.vue
@@ -34,6 +34,14 @@
         header="Version"
       />
       <Column
+        field="environment"
+        header="Environment"
+      >
+        <template #body="{ data }: { data: SessionCodec }">
+          <Tag severity="primary">{{ data.environment }}</Tag>
+        </template>
+      </Column>
+      <Column
         field="videoStatus"
         header="Video Conversion"
       >


### PR DESCRIPTION
### 🔖 Feature description

This feature was requests by a few members at [InternetBrands](https://www.internetbrands.com/). I'm creating this issue in their behalf.

We should be able to pass which environment Devqaly is running at

An example could be:

```ts
const devqalySDK = new DevqalySDK({
  projectKey: 'xxxx',
  environment: process.env.NODE_ENV,
})
```

### 🎤 Why is this feature needed ?

We would like to know which recordings have been recorded either in `staging` or `locally`.

This is also important when we implement new features down the road where we will need to known which environment it is running at.

### ✌️ How do you aim to achieve this?

An example could be:

```ts
const devqalySDK = new DevqalySDK({
  projectKey: 'xxxx',
  environment: process.env.NODE_ENV,
})
```

Some work would be necessary at the SDK repo. 

### 🔄️ Additional Information

_No response_

### 👀 Have you spent some time to check if this feature request has been raised before?

- [X] I checked and didn't find similar issue

### Are you willing to submit PR?

Yes I am willing to submit a PR!