### PR TITLE
Feature/remove primeflex

### DIFF
--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -25,7 +25,6 @@
     "mitt": "^3.0.0",
     "pinia": "^2.0.36",
     "platform": "^1.3.6",
-    "primeflex": "^3.3.0",
     "primeicons": "^6.0.1",
     "primevue": "^3.29.1",
     "qs": "^6.11.2",

--- a/apps/webapp/src/components/DCode.vue
+++ b/apps/webapp/src/components/DCode.vue
@@ -1,9 +1,11 @@
 <template>
   <pre
-    class="bg-slate-500 text-white p-4 rounded-md"
+    class="text-white p-1 rounded-md"
     style="tab-size: 6; white-space-collapse: preserve-breaks"
   >
+    <code>
     <slot></slot>
+    </code>
   </pre>
 </template>
 
@@ -35,7 +37,7 @@ pre {
   position: relative;
   margin: 0.5em 0;
   box-shadow: -1px 0px 0px 0px #358ccb, 0px 0px 0px 1px #dfdfdf;
-  border-left: 10px solid #358ccb;
+  border-left: 2px solid var(--blue-500);
   background-color: #fdfdfd;
   background-image: linear-gradient(transparent 50%, rgba(69, 142, 209, 0.04) 50%);
   background-size: 3em 3em;
@@ -52,3 +54,4 @@ code[class*='language'] {
   overflow: auto;
 }
 </style>
+<script setup></script>

--- a/apps/webapp/src/components/DCode.vue
+++ b/apps/webapp/src/components/DCode.vue
@@ -1,6 +1,6 @@
 <template>
   <pre
-    class="bg-black-alpha-90 text-white p-4 border-round-md"
+    class="bg-slate-500 text-white p-4 rounded-md"
     style="tab-size: 6; white-space-collapse: preserve-breaks"
   >
     <slot></slot>

--- a/apps/webapp/src/components/pages/projects/ProjectSettingsView/ClientSecuritySection.vue
+++ b/apps/webapp/src/components/pages/projects/ProjectSettingsView/ClientSecuritySection.vue
@@ -1,9 +1,9 @@
 <template>
-  <section class="border-round-md border-1 surface-border">
-    <div class="p-3 border-bottom-1 surface-border surface-ground">Client Security</div>
-    <div class="p-2">
-      <div class="flex align-items-center justify-content-between">
-        <div class="col-6">
+  <section class="rounded-md border border-slate-200">
+    <div class="p-3 border-b bg-slate-100">Client Security</div>
+    <div class="p-3">
+      <div class="flex items-center justify-between">
+        <div class="w-1/2">
           <span class="font-medium">Security Token</span>
           <div class="text-gray-500 text-xs mt-1">
             The security token is used to identify your backend when sending events to Devqaly's
@@ -16,7 +16,7 @@
             </div>
           </div>
         </div>
-        <div class="col-6">
+        <div class="w-1/2">
           <div class="p-inputgroup flex-1">
             <ConfirmDialog
               class="max-w-29rem"
@@ -74,7 +74,7 @@ const toast = useToast()
 async function onRefreshSecurityTokenClick() {
   confirm.require({
     message:
-      'Revoking the current security token will not allow events created by your backend to be created anymore UNTIL you update the security token in your codebase. Are you sure?',
+      'Revoking the current security token will not allow events created by your backend to be created anymore until you update the security token in your codebase. Are you sure?',
     header: 'Destructive action',
     acceptLabel: 'Yes, revoke current security token',
     accept: refreshSecurityToken,

--- a/apps/webapp/src/components/pages/projects/ProjectSettingsView/GeneralSettingsSection.vue
+++ b/apps/webapp/src/components/pages/projects/ProjectSettingsView/GeneralSettingsSection.vue
@@ -1,20 +1,20 @@
 <template>
-  <section class="border-round-md border-1 surface-border">
-    <div class="p-3 border-bottom-1 surface-border surface-ground">General Settings</div>
+  <section class="rounded-md border border-slate-200">
+    <div class="p-3 border-b bg-slate-100">General Settings</div>
 
-    <div class="p-2">
-      <div class="flex align-items-center justify-content-between">
-        <div class="col-6">
+    <div class="p-3">
+      <div class="flex items-center justify-between">
+        <div class="w-1/2">
           <span class="font-medium">Project Name</span>
           <div class="text-gray-500 text-xs mt-1">
             The current name of the project.
             <div class="font-bold">Currently it is not possible to change the name.</div>
           </div>
         </div>
-        <div class="col-6">
+        <div class="w-1/2">
           <InputText
             data-cy="project-settings-page__project-title"
-            class="surface-ground w-full"
+            class="!bg-slate-100 w-full"
             :value="projectStore.activeProject!.title"
             type="text"
             readonly
@@ -24,15 +24,15 @@
       </div>
     </div>
 
-    <div class="p-2 border-top-1 surface-border">
-      <div class="flex align-items-center justify-content-between">
-        <div class="col-6">
+    <div class="p-3 border-t border-slate-200">
+      <div class="flex items-center justify-between">
+        <div class="w-1/2">
           <span class="font-medium">Project Key</span>
           <div class="text-gray-500 text-xs mt-1">
             Use this key when implementing our Javascript SDK in your web application.
             <a
-              class="block"
-              href="https://docs.devqaly.com"
+              class="block underline"
+              href="https://docs.devqaly.com/getting-started/quick-start/"
               target="_blank"
               data-cy="project-settings-page__read-docs-link"
             >
@@ -40,7 +40,7 @@
             </a>
           </div>
         </div>
-        <div class="col-6">
+        <div class="w-1/2">
           <div class="p-inputgroup flex-1">
             <InputText
               data-cy="project-settings-page__project-key"

--- a/apps/webapp/src/components/resources/companyMember/InviteCompanyMember.vue
+++ b/apps/webapp/src/components/resources/companyMember/InviteCompanyMember.vue
@@ -46,12 +46,12 @@
           ref="emailsContainer"
         >
           <div
-            class="my-1 p-2 surface-ground border-round-md"
+            class="my-1 p-2 bg-slate-50 rounded-md"
             v-for="email in emails"
             :key="email"
           >
-            <div class="flex justify-content-between align-items-center">
-              <div class="flex gap-2 align-items-center">
+            <div class="flex justify-between items-center">
+              <div class="flex gap-2 items-center">
                 <span class="pi pi-user"></span>
 
                 <div v-text="email" />
@@ -72,7 +72,7 @@
           </div>
         </div>
 
-        <div class="mt-4 flex justify-content-between gap-4">
+        <div class="mt-4 flex justify-between gap-4">
           <Button
             data-cy="invite-company-member__close-dialog"
             @click="closeDialog"

--- a/apps/webapp/src/components/resources/project/SetupSDKDialog.vue
+++ b/apps/webapp/src/components/resources/project/SetupSDKDialog.vue
@@ -17,7 +17,7 @@
     <strong>main.js</strong>):
 
     <pre
-      class="bg-black-alpha-90 text-white p-4 border-round-md"
+      class="bg-slate-500 text-white p-5 rounded-md"
       style="tab-size: 6; white-space-collapse: preserve-breaks"
     >
         <!--   prettier-ignore -->

--- a/apps/webapp/src/components/resources/project/SetupSDKDialog.vue
+++ b/apps/webapp/src/components/resources/project/SetupSDKDialog.vue
@@ -17,17 +17,19 @@
     <strong>main.js</strong>):
 
     <pre
-      class="bg-slate-500 text-white p-5 rounded-md"
+      class="bg-slate-500 text-white rounded-md"
       style="tab-size: 6; white-space-collapse: preserve-breaks"
     >
-        <!--   prettier-ignore -->
-        import { DevqalySDK } from '@devqaly/browser'
+      <code>
+    <!--   prettier-ignore -->
+    import { DevqalySDK } from '@devqaly/browser'
 
-        const devqaly = new DevqalySDK({
-              projectKey: '{{project ? project.projectKey : ''}}'
-        })
+    const devqaly = new DevqalySDK({
+          projectKey: '{{project ? project.projectKey : ''}}'
+    })
 
-        devqaly.showRecordingButton()
+    devqaly.showRecordingButton()
+      </code>
     </pre>
   </Dialog>
 </template>

--- a/apps/webapp/src/layouts/NavigationLayout.vue
+++ b/apps/webapp/src/layouts/NavigationLayout.vue
@@ -1,23 +1,21 @@
 <template>
   <div>
-    <div class="min-h-screen flex relative lg:static surface-ground">
+    <div class="min-h-screen flex relative lg:static bg-slate-100">
       <div
         id="app-sidebar-1"
-        class="bg-slate-50 md:bg-transparent h-screen hidden lg:block flex-shrink-0 absolute lg:static left-0 top-0 z-1 select-none"
+        class="bg-slate-50 md:bg-transparent h-screen hidden lg:block shrink-0 absolute lg:static left-0 top-0 z-[1] select-none shadow-2xl md:shadow-none"
         style="width: 280px"
       >
-        <div class="flex flex-column h-full">
+        <div class="flex flex-col h-full">
           <div class="flex items-center shrink-0 content-center flex-col">
             <Image
-              class="mt-4 max-w-10rem"
+              class="mt-4 max-w-[10rem]"
               src="/logo--dark.svg"
               alt="Logo"
               height="45"
             />
 
-            <div
-              class="bg-blue-500 px-2 py-1 text-white border-round-xl font-bold text-xs mb-4 mt-2"
-            >
+            <div class="bg-blue-500 px-2 py-1 text-white rounded-md-xl font-bold text-xs mb-4 mt-2">
               beta
             </div>
           </div>
@@ -27,11 +25,11 @@
           />
 
           <div
-            class="mx-3 p-3 mt-4 border-round-md flex align-items-center text-white cursor-pointer bg-gradient-to-tr from-blue-500 to-blue-300"
+            class="mx-3 p-3 mt-4 rounded-md flex items-center text-white cursor-pointer bg-gradient-to-tr from-blue-500 to-blue-300"
             @click="onToggleCompaniesMenu"
           >
             <div
-              class="flex flex-column flex-grow-1"
+              class="flex flex-col grow"
               aria-controls="companies-menu"
             >
               <div
@@ -52,17 +50,17 @@
               :popup="true"
             />
 
-            <div class="flex-grow-0"><i class="pi pi-chevron-down"></i></div>
+            <div class="grow-0"><i class="pi pi-chevron-down"></i></div>
           </div>
 
           <div class="overflow-y-auto">
-            <ul class="list-none px-3 pt-0">
+            <ul class="list-none px-3 py-5">
               <!--              <li>-->
               <!--                <router-link-->
               <!--                  active-class="bg-bluegray-900 text-bluegray-50"-->
               <!--                  :to="{ name: 'dashboard' }"-->
               <!--                  v-ripple-->
-              <!--                  class="flex align-items-center cursor-pointer p-3 mt-1 hover:bg-bluegray-900 border-round text-bluegray-100 hover:text-bluegray-50 transition-duration-150 transition-colors p-ripple no-underline"-->
+              <!--                  class="flex items-center cursor-pointer p-3 mt-1 hover:bg-bluegray-900 rounded-md text-bluegray-100 hover:text-bluegray-50 transition-duration-150 transition-colors p-ripple no-underline"-->
               <!--                >-->
               <!--                  <i class="pi pi-home mr-2"></i>-->
               <!--                  <span class="font-medium">Dashboard</span>-->
@@ -75,9 +73,9 @@
                     name: 'listCompanyMembers',
                     params: { companyId: appStore.activeCompany!.id }
                   }"
-                  class="flex align-items-center cursor-pointer p-3 border-round text-slate-500 transition-all mt-2"
+                  class="flex items-center cursor-pointer p-4 rounded-md text-slate-500 transition-all mt-2"
                 >
-                  <i class="pi pi-users mr-2 bg-white p-2.5 border-round text-slate-800"></i>
+                  <i class="pi pi-users mr-2 bg-white p-2.5 rounded-md text-slate-800"></i>
                   <span class="font-medium">Members</span>
                 </router-link>
               </li>
@@ -85,9 +83,9 @@
                 <router-link
                   active-class="bg-white shadow-lg"
                   :to="{ name: 'listProjects' }"
-                  class="flex align-items-center cursor-pointer p-3 border-round text-slate-500 transition-all"
+                  class="flex items-center cursor-pointer p-4 rounded-md text-slate-500 transition-all"
                 >
-                  <i class="pi pi-server mr-2 bg-white p-2.5 border-round text-slate-800"></i>
+                  <i class="pi pi-server mr-2 bg-white p-2.5 rounded-md text-slate-800"></i>
                   <span class="font-medium">Projects</span>
                 </router-link>
               </li>
@@ -95,9 +93,9 @@
                 <router-link
                   active-class="bg-white shadow-lg"
                   :to="{ name: 'projectCreate' }"
-                  class="flex align-items-center cursor-pointer p-3 border-round text-slate-500 transition-all"
+                  class="flex items-center cursor-pointer p-4 rounded-md text-slate-500 transition-all"
                 >
-                  <i class="pi pi-plus mr-2 bg-white p-2.5 border-round text-slate-800"></i>
+                  <i class="pi pi-plus mr-2 bg-white p-2.5 rounded-md text-slate-800"></i>
                   <span class="font-medium">Create Project</span>
                 </router-link>
               </li>
@@ -153,22 +151,22 @@
 
             <router-link
               :to="{ name: 'authLogout' }"
-              class="mx-4 bg-white flex my-2 justify-center border-round py-2 font-bold text-xs"
+              class="mx-4 bg-white flex my-2 justify-center rounded-md py-2 font-bold text-xs shadow-sm"
             >
               Logout
             </router-link>
           </div>
         </div>
       </div>
-      <div class="min-h-screen flex flex-column relative flex-auto">
+      <div class="min-h-screen flex flex-col relative flex-auto">
         <div
-          class="flex justify-content-between align-items-center px-5 bg-transparent relative lg:static md:hidden"
+          class="flex content-between items-center px-5 bg-transparent relative lg:static md:hidden"
           style="height: 60px"
         >
           <div class="flex">
             <a
               v-ripple
-              class="cursor-pointer block lg:hidden text-700 mr-3 mt-1 p-ripple"
+              class="cursor-pointer block lg:hidden text-slate-700 mr-3 mt-1 p-ripple"
               v-styleclass="{
                 selector: '#app-sidebar-1',
                 enterClass: 'hidden',
@@ -183,7 +181,7 @@
           </div>
         </div>
         <div
-          class="flex flex-column flex-auto"
+          class="flex flex-col flex-auto"
           style="height: 80vh; overflow-y: scroll"
         >
           <router-view />

--- a/apps/webapp/src/layouts/NavigationLayout.vue
+++ b/apps/webapp/src/layouts/NavigationLayout.vue
@@ -109,7 +109,7 @@
                 style="background-image: url('/images/backgrounds/topography.png')"
               />
 
-              <div class="p-2">
+              <div class="p-3">
                 <div class="bg-white p-1 w-fit rounded-lg flex items-center justify-center">
                   <svg
                     xmlns="http://www.w3.org/2000/svg"

--- a/apps/webapp/src/layouts/NavigationLayout.vue
+++ b/apps/webapp/src/layouts/NavigationLayout.vue
@@ -15,7 +15,7 @@
               height="45"
             />
 
-            <div class="bg-blue-500 px-2 py-1 text-white rounded-md-xl font-bold text-xs mb-4 mt-2">
+            <div class="bg-blue-500 px-2 py-1 text-white rounded-full font-bold text-xs mb-4 mt-2">
               beta
             </div>
           </div>

--- a/apps/webapp/src/layouts/ProjectLayout.vue
+++ b/apps/webapp/src/layouts/ProjectLayout.vue
@@ -2,11 +2,11 @@
   <div>
     <div
       v-if="shouldShowSubscriptionWarning()"
-      class="surface-card border-round shadow-2 p-4 flex justify-content-between flex-column lg:flex-row align-items-center m-4 no-underline"
+      class="bg-white rounded-md shadow-md p-5 flex justify-between flex-col lg:flex-row items-center m-5 no-underline"
     >
       <div>
-        <div class="text-900 font-medium mb-3 text-xl">Free Subscription</div>
-        <p class="mt-0 mb-4 lg:mb-0 p-0 line-height-3">
+        <div class="font-semibold mb-3 text-xl">Free Subscription</div>
+        <p class="mt-0 mb-4 lg:mb-0 p-0">
           You currently have a free subscription for this company. You will be able to have active
           50 sessions for each project. On the 51st session, the first one will be archived.
         </p>
@@ -17,18 +17,17 @@
           label="Request Higher Limit"
           icon="pi pi-check"
           class="ml-0 lg:ml-5"
-        ></Button>
+        />
       </a>
     </div>
-    <div
-      class="surface-section overflow-x-auto border-bottom-1 surface-border m-4 border-round-lg shadow-2"
-    >
+    <div class="bg-white overflow-x-auto m-5 rounded-md shadow-md">
       <div class="mx-4 my-2">
-        <div class="flex justify-content-between align-items-center">
-          <div class="font-medium text-3xl mt-2 mb-1">
+        <div class="flex justify-between items-center">
+          <div class="font-medium text-3xl mt-3 mb-2">
             <Skeleton
               v-if="isFetchingActiveProject"
-              width="50px"
+              width="90px"
+              height="32px"
             />
 
             <span

--- a/apps/webapp/src/main.ts
+++ b/apps/webapp/src/main.ts
@@ -1,6 +1,5 @@
 import 'primevue/resources/themes/lara-light-blue/theme.css'
 import 'primevue/resources/primevue.min.css'
-import 'primeflex/primeflex.css'
 import 'primeicons/primeicons.css'
 import './global.css'
 

--- a/apps/webapp/src/views/auth/FinishRegistrationView.vue
+++ b/apps/webapp/src/views/auth/FinishRegistrationView.vue
@@ -1,16 +1,16 @@
 <template>
-  <div class="flex flex-column h-screen">
-    <div class="flex-shrink-1 flex-grow-0 border-bottom-1 border-200 px-6 py-2">
+  <div class="flex flex-col h-screen">
+    <div class="shrink grow-0 border-b border-gray-300 px-6 py-2">
       <Image
         src="/logo--dark.svg"
         alt="Logo"
-        width="250"
+        width="120"
       />
     </div>
 
-    <div class="flex flex-grow-1 flex-shrink-0">
+    <div class="flex grow shrink-0">
       <div
-        class="surface-section w-full lg:w-6 p-6 md:p-8"
+        class="w-full lg:w-1/2 p-6 md:p-8"
         style="
           display: grid;
           align-content: center;
@@ -19,7 +19,7 @@
         "
       >
         <div class="mb-5">
-          <div class="text-900 text-3xl font-medium mb-3">Let's get your started</div>
+          <div class="text-3xl font-medium mb-3">Let's get your started</div>
 
           <Form
             :initial-values="initialValues"
@@ -127,14 +127,14 @@
               label="Finish Set Up"
               icon="pi pi-chevron-right"
               iconPos="right"
-              class="w-full mt-4"
+              class="w-full !mt-4"
               type="submit"
             />
           </Form>
         </div>
       </div>
       <div
-        class="hidden lg:block w-6 bg-no-repeat bg-cover"
+        class="hidden lg:block w-1/2 bg-no-repeat bg-cover"
         style="
           background-image: url('https://blocks.primeng.org/assets/images/blocks/signin/signin.jpg');
         "

--- a/apps/webapp/src/views/auth/LoginView.vue
+++ b/apps/webapp/src/views/auth/LoginView.vue
@@ -1,16 +1,16 @@
 <template>
-  <div class="flex flex-column h-screen">
-    <div class="flex-shrink-1 flex-grow-0 border-bottom-1 border-200 px-6 py-2">
+  <div class="flex flex-col h-screen">
+    <div class="shrink grow-0 border-b border-gray-300 px-6 py-2">
       <Image
         src="/logo--dark.svg"
         alt="Logo"
-        width="250"
+        width="120"
       />
     </div>
 
-    <div class="flex flex-grow-1 flex-shrink-0">
+    <div class="flex grow shrink-0">
       <div
-        class="surface-section w-full lg:w-6 p-6 md:p-8"
+        class="w-full lg:w-1/2 p-6 md:p-8"
         style="
           display: grid;
           align-content: center;
@@ -19,7 +19,7 @@
         "
       >
         <div class="mb-5">
-          <div class="text-900 text-3xl font-medium mb-3">Login</div>
+          <div class="text-3xl font-medium mb-3">Login</div>
         </div>
         <Form
           :initial-values="initialValues"
@@ -75,11 +75,11 @@
             data-cy="login-view__submit"
             :loading="isLoggingIn"
             label="Sign in"
-            class="w-full mt-4"
+            class="w-full !mt-4"
             type="submit"
           />
 
-          <div class="mx-auto block text-center mt-2 text-500">
+          <div class="mx-auto block text-center mt-2 text-slate-400">
             <!--            <div class="mt-4">-->
             <!--              Don't have an account?-->
             <!--              <router-link-->
@@ -104,7 +104,7 @@
         </Form>
       </div>
       <div
-        class="hidden lg:block w-6 bg-no-repeat bg-cover"
+        class="hidden lg:block w-1/2 bg-no-repeat bg-cover"
         style="
           background-image: url('https://blocks.primeng.org/assets/images/blocks/signin/signin.jpg');
         "

--- a/apps/webapp/src/views/auth/LogoutView.vue
+++ b/apps/webapp/src/views/auth/LogoutView.vue
@@ -1,8 +1,8 @@
 <template>
-  <div class="h-screen flex justify-content-center align-items-center surface-ground">
-    <div class="surface-card p-4 shadow-2 border-round w-full lg:w-4">
+  <div class="h-screen flex justify-center items-center bg-slate-100">
+    <div class="bg-white p-4 shadow-md rounded-lg w-full lg:max-w-[450px]">
       <div class="text-center mb-4">Logging you out</div>
-      <ProgressSpinner class="block" />
+      <ProgressSpinner class="!block" />
     </div>
   </div>
 </template>

--- a/apps/webapp/src/views/auth/RequestPasswordResetView.vue
+++ b/apps/webapp/src/views/auth/RequestPasswordResetView.vue
@@ -1,16 +1,16 @@
 <template>
-  <div class="flex flex-column h-screen">
-    <div class="flex-shrink-1 flex-grow-0 border-bottom-1 border-200 px-6 py-2">
+  <div class="flex flex-col h-screen">
+    <div class="shrink grow-0 border-b border-gray-300 px-6 py-2">
       <Image
         src="/logo--dark.svg"
         alt="Logo"
-        width="250"
+        width="120"
       />
     </div>
 
-    <div class="flex flex-grow-1 flex-shrink-0">
+    <div class="flex grow shrink-0">
       <div
-        class="surface-section w-full lg:w-6 p-6 md:p-8"
+        class="w-full lg:w-1/2 p-6 md:p-8"
         style="
           display: grid;
           align-content: center;
@@ -19,7 +19,7 @@
         "
       >
         <div class="mb-5">
-          <div class="text-900 text-3xl font-medium mb-3">Reset Password</div>
+          <div class="text-3xl font-medium mb-3">Reset Password</div>
 
           <div
             v-if="linkRequested"
@@ -59,11 +59,11 @@
               data-cy="request-password-reset__submit"
               :loading="isRequestingPasswordLink"
               label="Request Link"
-              class="w-full mt-4"
+              class="w-full !mt-4"
               type="submit"
             ></Button>
 
-            <div class="mx-auto block text-center mt-2 text-500">
+            <div class="mx-auto block text-center mt-2 text-slate-400">
               <div class="mt-4">
                 Already Have An Account?
                 <router-link
@@ -88,7 +88,7 @@
         </div>
       </div>
       <div
-        class="hidden lg:block w-6 bg-no-repeat bg-cover"
+        class="hidden lg:block w-1/2 bg-no-repeat bg-cover"
         style="
           background-image: url('https://blocks.primeng.org/assets/images/blocks/signin/signin.jpg');
         "

--- a/apps/webapp/src/views/auth/ResetPasswordView.vue
+++ b/apps/webapp/src/views/auth/ResetPasswordView.vue
@@ -1,16 +1,16 @@
 <template>
-  <div class="flex flex-column h-screen">
-    <div class="flex-shrink-1 flex-grow-0 border-bottom-1 border-200 px-6 py-2">
+  <div class="flex flex-col h-screen">
+    <div class="shrink grow-0 border-b border-gray-300 px-6 py-2">
       <Image
         src="/logo--dark.svg"
         alt="Logo"
-        width="250"
+        width="120"
       />
     </div>
 
-    <div class="flex flex-grow-1 flex-shrink-0">
+    <div class="flex grow shrink-0">
       <div
-        class="surface-section w-full lg:w-6 p-6 md:p-8"
+        class="w-full lg:w-1/2 p-6 md:p-8"
         style="
           display: grid;
           align-content: center;
@@ -19,7 +19,7 @@
         "
       >
         <div class="mb-5">
-          <div class="text-900 text-3xl font-medium mb-3">Reset Password</div>
+          <div class="text-3xl font-medium mb-3">Reset Password</div>
 
           <Form
             :initial-values="initialValues"
@@ -75,14 +75,14 @@
               data-cy="reset-password-view__submit"
               :loading="isResettingPassword"
               label="Reset Password"
-              class="w-full mt-4"
+              class="w-full !mt-4"
               type="submit"
             />
           </Form>
         </div>
       </div>
       <div
-        class="hidden lg:block w-6 bg-no-repeat bg-cover"
+        class="hidden lg:block w-1/2 bg-no-repeat bg-cover"
         style="
           background-image: url('https://blocks.primeng.org/assets/images/blocks/signin/signin.jpg');
         "

--- a/apps/webapp/src/views/companies/CreateCompanyView.vue
+++ b/apps/webapp/src/views/companies/CreateCompanyView.vue
@@ -11,7 +11,7 @@
       @submit="onSubmit"
     >
       <div class="bg-white shadow-md rounded-lg p-5">
-        <div class="text-900 font-medium mb-5">General Information</div>
+        <div class="font-medium mb-5">General Information</div>
 
         <Field
           name="name"

--- a/apps/webapp/src/views/companies/CreateCompanyView.vue
+++ b/apps/webapp/src/views/companies/CreateCompanyView.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="p-5">
-    <div class="text-3xl font-medium text-900">Create Company</div>
-    <div class="font-medium text-500 mb-3">
+    <div class="text-3xl font-medium">Create Company</div>
+    <div class="font-medium text-slate-500 mb-4">
       A company allows you to aggregate projects inside an organization
     </div>
 
@@ -10,13 +10,8 @@
       autofocus
       @submit="onSubmit"
     >
-      <div class="surface-card p-4 shadow-2 border-round">
-        <div class="flex w-full relative align-items-center justify-content-start mb-4 px-2">
-          <div class="border-top-1 surface-border top-50 left-0 absolute w-full"></div>
-          <div class="px-2 z-1 surface-0 flex align-items-center">
-            <span class="text-900 font-medium">General Information</span>
-          </div>
-        </div>
+      <div class="bg-white shadow-md rounded-lg p-5">
+        <div class="text-900 font-medium mb-5">General Information</div>
 
         <Field
           name="name"
@@ -40,10 +35,10 @@
           >
         </Field>
 
-        <div class="flex justify-content-end">
+        <div class="flex justify-end">
           <Button
             data-cy="create-company-view__submit"
-            class="mt-4"
+            class="!mt-4"
             :loading="isCreatingCompany"
             icon="pi pi-chevron-right"
             icon-pos="right"

--- a/apps/webapp/src/views/companies/ListCompanyMembers.vue
+++ b/apps/webapp/src/views/companies/ListCompanyMembers.vue
@@ -1,10 +1,10 @@
 <template>
   <div class="p-5">
     <div class="text-3xl font-medium text-900">Members</div>
-    <div class="font-medium text-500 mb-3">See the members that are part of this company</div>
+    <div class="font-medium text-slate-500 mb-4">See the members that are part of this company</div>
 
-    <div class="surface-card shadow-2 border-round-lg">
-      <div class="p-4 flex justify-content-between align-items-center">
+    <div class="bg-white shadow-2 rounded-lg">
+      <div class="p-5 flex justify-between items-center">
         <FiltersSection
           :filters="filters"
           @update:filters="onFilterUpdate"

--- a/apps/webapp/src/views/companies/ListCompanyMembers.vue
+++ b/apps/webapp/src/views/companies/ListCompanyMembers.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="p-5">
-    <div class="text-3xl font-medium text-900">Members</div>
+    <div class="text-3xl font-medium">Members</div>
     <div class="font-medium text-slate-500 mb-4">See the members that are part of this company</div>
 
-    <div class="bg-white shadow-2 rounded-lg">
+    <div class="bg-white shadow-md rounded-lg">
       <div class="p-5 flex justify-between items-center">
         <FiltersSection
           :filters="filters"

--- a/apps/webapp/src/views/projects/CreateProjectView.vue
+++ b/apps/webapp/src/views/projects/CreateProjectView.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="p-5">
-    <div class="text-3xl font-medium text-900">Create Project</div>
-    <div class="font-medium text-500 mb-3">
+    <div class="text-3xl font-medium">Create Project</div>
+    <div class="font-medium text-slate-500 mb-4">
       A project allows you to group your sessions in a logical manner and collaborate with
       colleagues
     </div>
@@ -10,13 +10,8 @@
       :validation-schema="validationSchema"
       @submit="onSubmit"
     >
-      <div class="surface-card p-4 shadow-2 border-round">
-        <div class="flex w-full relative align-items-center justify-content-start mb-4 px-2">
-          <div class="border-top-1 surface-border top-50 left-0 absolute w-full"></div>
-          <div class="px-2 z-1 surface-0 flex align-items-center">
-            <span class="text-900 font-medium">General Information</span>
-          </div>
-        </div>
+      <div class="bg-white p-4 shadow-md rounded-lg">
+        <div class="font-medium mb-5">General Information</div>
 
         <Field
           name="title"
@@ -40,10 +35,10 @@
           >
         </Field>
 
-        <div class="flex justify-content-end">
+        <div class="flex justify-end">
           <Button
             data-cy="create-project-view__submit"
-            class="mt-4"
+            class="!mt-4"
             :loading="isCreatingProject"
             icon="pi pi-chevron-right"
             icon-pos="right"

--- a/apps/webapp/src/views/projects/CreateProjectView.vue
+++ b/apps/webapp/src/views/projects/CreateProjectView.vue
@@ -10,7 +10,7 @@
       :validation-schema="validationSchema"
       @submit="onSubmit"
     >
-      <div class="bg-white p-4 shadow-md rounded-lg">
+      <div class="bg-white p-5 shadow-md rounded-lg">
         <div class="font-medium mb-5">General Information</div>
 
         <Field

--- a/apps/webapp/src/views/projects/ListProjectsView.vue
+++ b/apps/webapp/src/views/projects/ListProjectsView.vue
@@ -1,16 +1,18 @@
 <template>
   <div class="p-5">
-    <div class="text-3xl font-medium text-900">My Projects</div>
-    <div class="font-medium text-500 mb-3">The projects you are a member of will show up here</div>
+    <div class="text-3xl font-medium">My Projects</div>
+    <div class="font-medium text-slate-500 mb-4">
+      The projects you are a member of will show up here
+    </div>
 
     <SetupSDKDialog
       :project="activeProjectForIntegration"
       @close="onIntegrationDetailsModalCLose"
     />
 
-    <div class="surface-card shadow-2 border-round-lg">
+    <div class="bg-white shadow-lg rounded-lg">
       <ProjectFilters
-        class="p-4"
+        class="p-5"
         :title="filters.title ?? ''"
         @update:filters="onFilterUpdate"
       />

--- a/apps/webapp/src/views/projects/ProjectDashboard.vue
+++ b/apps/webapp/src/views/projects/ProjectDashboard.vue
@@ -11,18 +11,21 @@
     <strong>main.js</strong>):
 
     <pre
-      class="bg-black-alpha-90 text-white p-4 border-round-md"
+      class="text-white p-4 rounded-md"
       style="tab-size: 6; white-space-collapse: preserve-breaks"
     >
-import { DevqalySDK } from '@devqaly/browser'
+      <code class='block whitespace-pre overflow-x-scroll'>
+    import { DevqalySDK } from '@devqaly/browser'
 
-        const devqaly = new DevqalySDK({
-              projectKey: '{{
-        projectStore.activeProject ? projectStore.activeProject.projectKey : ''
+    const devqaly = new DevqalySDK({
+      projectKey: '{{
+      projectStore.activeProject ? projectStore.activeProject.projectKey : ''
       }}'
-        })
+    })
 
-        devqaly.showRecordingButton()
+    devqaly.showRecordingButton()
+</code>
+
     </pre>
 
     <Message :closable="false">

--- a/apps/webapp/src/views/projects/ProjectSettingsView.vue
+++ b/apps/webapp/src/views/projects/ProjectSettingsView.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="p-4">
     <GeneralSettingsSection />
-    <ClientSecuritySection class="mt-4" />
+    <ClientSecuritySection class="mt-5" />
   </div>
 </template>
 

--- a/apps/webapp/yarn.lock
+++ b/apps/webapp/yarn.lock
@@ -3326,11 +3326,6 @@ pretty-format@^27.5.1:
     ansi-styles "^5.0.0"
     react-is "^17.0.1"
 
-primeflex@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/primeflex/-/primeflex-3.3.0.tgz#6c755230ddf30c8fffed9f817efed28d5fe2bdff"
-  integrity sha512-4hvyIO7lERN5bnyURn67Qpozghins8Jq/GSXO6tymc3oa2ADHWuiYBti8ZptPwHu+uD/HTEisS26NEmeIGfPZQ==
-
 primeicons@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/primeicons/-/primeicons-6.0.1.tgz#431fa7c79825934eefd62087d8e1faa6a9e376ad"


### PR DESCRIPTION
See #98 
Closes #98 

### 🔖 Feature description

After implementing recent design updates, Tailwind has been incorporated into our project. The primary motivation behind adopting Tailwind was to enhance our ability to manipulate specific elements without the necessity of creating custom classes.

At present, both primeflexcss and Tailwind are components of our project. The objective of this task is to entirely eliminate primeflexcss from our project and exclusively utilize tailwindcss.

### 🎤 Why is this feature needed ?

We do not need to have both Primeflex and Tailwind since both of them serve the same purpose.

### ✌️ How do you aim to achieve this?

Replacing classes from primeflex with tailwind's. 

### 🔄️ Additional Information

_No response_

### 👀 Have you spent some time to check if this feature request has been raised before?

- [X] I checked and didn't find similar issue

### Are you willing to submit PR?

Yes I am willing to submit a PR!