### PR TITLE
Feature/copy link to session

### DIFF
--- a/apps/api/routes/api/resources/sessions.php
+++ b/apps/api/routes/api/resources/sessions.php
@@ -10,9 +10,9 @@ Route::post('sessions/{projectSession}/video', [SessionController::class, 'store
 
 Route::get('sessions/{session}/video', [SessionController::class, 'streamVideo'])->name('sessions.streamVideo');
 
-Route::middleware('auth:sanctum')->group(function () {
-    Route::get('sessions/{session}', [SessionController::class, 'show'])->name('sessions.show');
+Route::get('sessions/{session}', [SessionController::class, 'show'])->name('sessions.show');
 
+Route::middleware('auth:sanctum')->group(function () {
     Route::get('sessions/{projectSession}/events', [SessionEventController::class, 'index'])->name('sessions.events.index');
 
     Route::post('sessions/{session}/assign', [SessionController::class, 'assignSessionToLoggedUser'])

--- a/apps/api/tests/Feature/Http/Controllers/Resources/SessionControllerTest.php
+++ b/apps/api/tests/Feature/Http/Controllers/Resources/SessionControllerTest.php
@@ -32,7 +32,7 @@ class SessionControllerTest extends TestCase
             ->assertJsonPath('data.id', $session->id);
     }
 
-    public function test_non_company_member_cant_see_session(): void
+    public function test_non_company_member_cant_see_full_session(): void
     {
         $session = Session::factory()->create();
 
@@ -44,7 +44,24 @@ class SessionControllerTest extends TestCase
             ->getJson(route('sessions.show', [
                 'session' => $session
             ]))
-            ->assertForbidden();
+            ->assertOk()
+            ->assertJsonPath('data.id', $session->id)
+            ->assertJsonPath('data.project.id', $session->project->id)
+            ->assertJsonMissingPath('data.videoUrl');
+    }
+
+    public function test_guest_user_can_see_session(): void
+    {
+        $session = Session::factory()->create();
+
+        $this
+            ->getJson(route('sessions.show', [
+                'session' => $session
+            ]))
+            ->assertOk()
+            ->assertJsonPath('data.id', $session->id)
+            ->assertJsonPath('data.project.id', $session->project->id)
+            ->assertJsonMissingPath('data.videoUrl');
     }
 
     public function test_company_member_can_assign_session_to_him(): void

--- a/apps/webapp/src/router/children/sessionRoutes.ts
+++ b/apps/webapp/src/router/children/sessionRoutes.ts
@@ -6,7 +6,7 @@ export const sessionRoutes: RouteRecordRaw[] = [
     name: 'assignSessionToLoggedUser',
     component: () => import('@/views/sessions/AssignSessionCurrentlyLoggedUserView.vue'),
     meta: {
-      requiresAuth: true
+      requiresAuth: false
     }
   }
 ]

--- a/apps/webapp/src/stores/app.ts
+++ b/apps/webapp/src/stores/app.ts
@@ -16,7 +16,6 @@ import type { GetLoggedUserCompaniesParameters } from '@/services/api/resources/
 import type { AxiosError } from 'axios'
 import { isAxiosError } from 'axios'
 import { StatusCodes } from 'http-status-codes'
-import { useRouter } from 'vue-router'
 
 interface AppStoreState {
   isAuthenticated: boolean

--- a/apps/webapp/src/views/sessions/AssignSessionCurrentlyLoggedUserView.vue
+++ b/apps/webapp/src/views/sessions/AssignSessionCurrentlyLoggedUserView.vue
@@ -1,17 +1,67 @@
 <template>
-  <div class="h-screen w-screen grid flex-column justify-content-center align-items-center">
-    Assigning session to your account
+  <div
+    class="h-screen w-screen grid flex-column justify-center items-center"
+    v-if="isFetchingSessionInformation"
+  >
+    <Card class="shadow-md h-fit flex flex-col p-5 mx-auto text-slate-500">
+      Fetching information about your session
 
-    <ProgressSpinner class="mt-2" />
+      <ProgressSpinner
+        class="!mt-4"
+        style="width: 50px; height: 50px"
+        stroke-width="2"
+      />
+    </Card>
+  </div>
+
+  <div
+    class="h-screen w-screen grid flex-column justify-center items-center"
+    v-if="isAssigningSessionToUser"
+  >
+    <Card class="shadow-md h-fit flex flex-col p-5 mx-auto text-center text-slate-500">
+      Assigning session to your account
+
+      <ProgressSpinner
+        class="!mt-4"
+        style="width: 50px; height: 50px"
+        stroke-width="2"
+      />
+    </Card>
+  </div>
+
+  <div
+    v-else
+    class="h-screen w-screen grid flex-column content-center items-center"
+  >
+    <Card class="w-1/2 shadow-md h-fit flex flex-col p-5 mx-auto max-w-[450px] text-center">
+      <h1 class="text-3xl mb-2">Session Created</h1>
+
+      <span class="text-slate-500">
+        You can share this session with a developer by copying the link below. <br />
+      </span>
+
+      <Button
+        label="Copy Session URL"
+        class="w-full !mt-4"
+        outlined
+        @click="copySessionUrl"
+      />
+
+      <span class="text-xs text-slate-500 text-center">
+        You will have to ask a team member to be invited to the project in order to claim this
+        session.
+      </span>
+    </Card>
   </div>
 </template>
 
 <script setup lang="ts">
-import { onMounted } from 'vue'
-import { assignSessionToUser } from '@/services/api/resources/session/actions'
+import { onMounted, ref } from 'vue'
+import { assignSessionToUser, getSession } from '@/services/api/resources/session/actions'
 import { useRoute, useRouter } from 'vue-router'
 import { useToast } from 'primevue/usetoast'
 import { useAppStore } from '@/stores/app'
+import { sessionsCodecFactory } from '@/services/factories/sessionsFactory'
 
 const toast = useToast()
 
@@ -21,8 +71,18 @@ const router = useRouter()
 
 const appStore = useAppStore()
 
-onMounted(async () => {
+const isAssigningSessionToUser = ref(false)
+
+const session = ref(sessionsCodecFactory())
+
+const isFetchingSessionInformation = ref(true)
+
+async function assignSessionToLoggedUser() {
+  if (!appStore.isAuthenticated) return
+
   try {
+    isAssigningSessionToUser.value = true
+
     const response = await assignSessionToUser(route.params.sessionId as string, {
       userId: appStore.loggedUser.id
     })
@@ -44,5 +104,74 @@ onMounted(async () => {
       group: 'bottom-center'
     })
   }
+}
+
+async function fetchSessionInformation() {
+  try {
+    isFetchingSessionInformation.value = true
+
+    const response = await getSession(route.params.sessionId as string)
+
+    session.value = response.data.data
+    isFetchingSessionInformation.value = false
+  } catch (e) {
+    toast.add({
+      severity: 'error',
+      summary: 'Error fetching session',
+      detail: 'There was an error fetching session information',
+      life: 15000,
+      group: 'bottom-center'
+    })
+  }
+}
+
+function copySessionUrl() {
+  if (!session.value.project) {
+    throw new Error('`session.value.project` should be defined')
+  }
+
+  const url = router.resolve({
+    name: 'projectSession',
+    params: {
+      projectId: session.value.project.id,
+      sessionId: route.params.sessionId as string
+    }
+  })
+
+  if (!navigator.clipboard) {
+    toast.add({
+      severity: 'error',
+      summary: 'Error Copying',
+      detail: 'Your browser do not support navigator.clipboard',
+      life: 3000,
+      group: 'bottom-center'
+    })
+
+    return
+  }
+
+  navigator.clipboard
+    .writeText(new URL(url.href, window.location.origin).href)
+    .then(() => {
+      toast.add({
+        severity: 'success',
+        summary: 'Copied successfully',
+        detail: 'Successfully copied content to clipboard',
+        life: 3000
+      })
+    })
+    .catch(() => {
+      toast.add({
+        severity: 'error',
+        summary: 'Error Copying',
+        detail: 'There was an error copying the content',
+        life: 3000
+      })
+    })
+}
+
+onMounted(async () => {
+  await fetchSessionInformation()
+  await assignSessionToLoggedUser()
 })
 </script>


### PR DESCRIPTION
Closes #99 

### 🔖 Feature description

Currently, individuals who are not logged into the web application, upon creating a session in a third-party app, are redirected to Devqaly's web app to associate the session with themselves.

If the user is not logged in, they receive a notification stating: "Error assigning session to you. There was an error assigning this session to you. We will redirect you in 10 seconds, and this session will be unassigned."

This poses an issue where a QA or a Developer recording a session in a third-party app may face challenges. Upon redirection, they won't have the link to the recorded session, making it impossible to share the direct recording in a Jira ticket.

### 🎤 Why is this feature needed ?

Upon completion of this feature, any individual recording a session in a third-party app will have the capability to receive a direct link to the recording.

### ✌️ How do you aim to achieve this?

In the `apps/webapp/src/views/sessions/AssignSessionCurrentlyLoggedUserView.vue` component, instead of presenting the error message "There was an error assigning this session to you. We will redirect you in 10 seconds, and this session will be unassigned," it now displays the link for developers to access the recording.

### 🔄️ Additional Information

_No response_

### 👀 Have you spent some time to check if this feature request has been raised before?

- [X] I checked and didn't find similar issue

### Are you willing to submit PR?

Yes I am willing to submit a PR!