### PR TITLE
Add unique email to users

### DIFF
--- a/apps/api/database/factories/UserFactory.php
+++ b/apps/api/database/factories/UserFactory.php
@@ -21,7 +21,7 @@ class UserFactory extends Factory
         return [
             'first_name' => fake()->firstName(),
             'last_name' => fake()->lastName(),
-            'email' => fake()->unique()->safeEmail(),
+            'email' => sprintf('bruno-test-%s@devqaly.com', rand(1, 999999)),
             'timezone' => fake()->timezone(),
             'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
             'remember_token' => Str::random(10),


### PR DESCRIPTION
- added a random number when creating emails for users
	- for some reason faker's `unique()` constraint is not being unique, causing pipelines to fail
- closes #116 