### PR TITLE
Feature/able to share company url

### DIFF
--- a/apps/api/app/Http/Controllers/Resources/SessionController.php
+++ b/apps/api/app/Http/Controllers/Resources/SessionController.php
@@ -46,10 +46,7 @@ class SessionController extends Controller
 
         return response()->json(['data' => [
             ...$session->only('id'),
-            'project' => [
-                ...$session->project->only('id'),
-                'company' => $session->project->company()->select('id')->first()->only('id'),
-            ],
+            'project' => $session->project->only('id'),
         ]]);
     }
 

--- a/apps/api/app/Http/Controllers/Resources/SessionController.php
+++ b/apps/api/app/Http/Controllers/Resources/SessionController.php
@@ -46,7 +46,10 @@ class SessionController extends Controller
 
         return response()->json(['data' => [
             ...$session->only('id'),
-            'project' => $session->project->only('id')
+            'project' => [
+                ...$session->project->only('id'),
+                'company' => $session->project->company()->select('id')->first()->only('id'),
+            ],
         ]]);
     }
 

--- a/apps/api/app/Http/Controllers/Resources/SessionController.php
+++ b/apps/api/app/Http/Controllers/Resources/SessionController.php
@@ -34,7 +34,10 @@ class SessionController extends Controller
         if (!$user) {
             return response()->json(['data' => [
                 ...$session->only('id'),
-                'project' => $session->project->only('id')
+                'project' => [
+                    ...$session->project->only('id'),
+                    'company' => $session->project->company()->select('id')->first()->only('id'),
+                ]
             ]]);
         }
 
@@ -46,7 +49,10 @@ class SessionController extends Controller
 
         return response()->json(['data' => [
             ...$session->only('id'),
-            'project' => $session->project->only('id'),
+            'project' => [
+                ...$session->project->only('id'),
+                'company' => $session->project->company()->select('id')->first()->only('id'),
+            ],
         ]]);
     }
 

--- a/apps/api/app/Http/Controllers/Resources/SessionController.php
+++ b/apps/api/app/Http/Controllers/Resources/SessionController.php
@@ -42,7 +42,7 @@ class SessionController extends Controller
         }
 
         if ($user->can('view', $session)) {
-            $session->load('createdBy');
+            $session->load(['createdBy', 'project.company']);
 
             return new SessionResource($session);
         }

--- a/apps/api/app/Http/Resources/Resources/ProjectResource.php
+++ b/apps/api/app/Http/Resources/Resources/ProjectResource.php
@@ -15,6 +15,7 @@ class ProjectResource extends JsonResource
             'projectKey' => $this->project_key,
             'securityToken' => $this->security_token,
             'createdAt' => $this->created_at,
+            'company' => new CompanyResource($this->whenLoaded('company'))
         ];
     }
 }

--- a/apps/webapp/cypress/e2e/views/companies/CreateCompanyView.vue.spec.ts
+++ b/apps/webapp/cypress/e2e/views/companies/CreateCompanyView.vue.spec.ts
@@ -22,9 +22,9 @@ describe('CreateCompanyView.vue', () => {
       expect(response?.statusCode).to.be.eq(201)
       expect(response?.body.data).to.haveOwnProperty('id')
       expect(response?.body.data.name).to.be.eq(companyName)
-    })
 
-    cy.url().should('contain', 'projects')
+      cy.url().should('contain', `company/${response?.body.data.id}/projects`)
+    })
 
     cy.dataCy('navigation-layout__active-company').should('have.text', companyName)
   })

--- a/apps/webapp/cypress/e2e/views/projects/CreateProjectView.vue.spec.ts
+++ b/apps/webapp/cypress/e2e/views/projects/CreateProjectView.vue.spec.ts
@@ -14,7 +14,7 @@ describe('CreateProjectView.vue', () => {
   it('should allow to create correct project', () => {
     cy.intercept('POST', `api/companies/${companyId}/projects`).as('createProjectRequest')
 
-    cy.visit('/projects/create')
+    cy.visit(`/company/${companyId}/projects/create`)
 
     const projectName = 'project super awesome ' + Math.random().toString().slice(2, 8)
 

--- a/apps/webapp/cypress/e2e/views/projects/ListProjectsView.vue.spec.ts
+++ b/apps/webapp/cypress/e2e/views/projects/ListProjectsView.vue.spec.ts
@@ -25,7 +25,7 @@ describe('ListProjectsView.vue', () => {
   it('should display correct projects', () => {
     cy.intercept('GET', `**/companies/${companyId}/projects**`).as('projectsRequest')
 
-    cy.visit('/projects')
+    cy.visit(`company/${companyId}/projects`)
 
     cy.wait('@projectsRequest').then(({ request, response }) => {
       expect(request.url).to.contain(`perPage=${perPage}`)
@@ -58,7 +58,7 @@ describe('ListProjectsView.vue', () => {
   it('should open modal when clicking to view integration details', () => {
     cy.intercept('GET', `**/companies/${companyId}/projects**`).as('projectsRequest')
 
-    cy.visit('/projects')
+    cy.visit(`company/${companyId}/projects`)
 
     cy.wait('@projectsRequest')
 
@@ -73,7 +73,7 @@ describe('ListProjectsView.vue', () => {
 
       const searchTitle = projects[0].title
 
-      cy.visit('/projects')
+      cy.visit(`company/${companyId}/projects`)
 
       cy.wait('@projectsRequest')
 
@@ -97,7 +97,7 @@ describe('ListProjectsView.vue', () => {
     it('should display correct values when jumping to next page', () => {
       cy.intercept('GET', `**/companies/${companyId}/projects**`).as('projectsRequest')
 
-      cy.visit('/projects')
+      cy.visit(`company/${companyId}/projects`)
 
       cy.wait('@projectsRequest')
 

--- a/apps/webapp/cypress/e2e/views/projects/ProjectDashboard.vue.spec.ts
+++ b/apps/webapp/cypress/e2e/views/projects/ProjectDashboard.vue.spec.ts
@@ -20,7 +20,7 @@ describe('ProjectDashboard.vue', () => {
   it('should show how to setup the SDK', () => {
     cy.intercept('GET', `**/api/projects/${project.id}`).as('getProjectRequest')
 
-    cy.visit(`projects/${project.id}/dashboard`)
+    cy.visit(`company/${companyId}/projects/${project.id}/dashboard`)
 
     cy.wait('@getProjectRequest')
 

--- a/apps/webapp/cypress/e2e/views/projects/ProjectSessionView.vue.spec.ts
+++ b/apps/webapp/cypress/e2e/views/projects/ProjectSessionView.vue.spec.ts
@@ -93,7 +93,7 @@ describe('ProjectSessionView.vue', () => {
   it('should display correct information for session with converted video', () => {
     cy.intercept('GET', `**/api/sessions/${sessionWithConvertedVideo.id}`).as('fetchSession')
 
-    cy.visit(`projects/${project.id}/sessions/${sessionWithConvertedVideo.id}`)
+    cy.visit(`company/${companyId}/projects/${project.id}/sessions/${sessionWithConvertedVideo.id}`)
 
     cy.wait('@fetchSession')
 
@@ -138,7 +138,9 @@ describe('ProjectSessionView.vue', () => {
       'fetchSession'
     )
 
-    cy.visit(`projects/${project.id}/sessions/${sessionWithInQueueForConvertingVideo.id}`)
+    cy.visit(
+      `company/${companyId}/projects/${project.id}/sessions/${sessionWithInQueueForConvertingVideo.id}`
+    )
 
     cy.wait('@fetchSession')
 
@@ -156,7 +158,9 @@ describe('ProjectSessionView.vue', () => {
 
       const VIDEO_PARTITION_SIZES = 10
 
-      cy.visit(`projects/${project.id}/sessions/${sessionWithConvertedVideo.id}`)
+      cy.visit(
+        `company/${companyId}/projects/${project.id}/sessions/${sessionWithConvertedVideo.id}`
+      )
 
       cy.wait('@fetchSession')
 
@@ -201,7 +205,9 @@ describe('ProjectSessionView.vue', () => {
         fixture: 'test-video.webm,null'
       }).as('videoRequest')
 
-      cy.visit(`projects/${project.id}/sessions/${sessionWithConvertedVideo.id}`)
+      cy.visit(
+        `company/${companyId}/projects/${project.id}/sessions/${sessionWithConvertedVideo.id}`
+      )
 
       cy.dataCy('project-session-view__video')
         .should('have.prop', 'paused', true)
@@ -232,7 +238,9 @@ describe('ProjectSessionView.vue', () => {
         'fetchSessionEvents'
       )
 
-      cy.visit(`projects/${project.id}/sessions/${sessionWithConvertedVideo.id}`)
+      cy.visit(
+        `company/${companyId}/projects/${project.id}/sessions/${sessionWithConvertedVideo.id}`
+      )
 
       cy.wait(['@fetchSession', '@fetchSessionEvents'])
 
@@ -483,7 +491,9 @@ describe('ProjectSessionView.vue', () => {
         'fetchSessionEvents'
       )
 
-      cy.visit(`projects/${project.id}/sessions/${sessionWithConvertedVideo.id}`)
+      cy.visit(
+        `company/${companyId}/projects/${project.id}/sessions/${sessionWithConvertedVideo.id}`
+      )
 
       cy.wait('@fetchSession')
 
@@ -597,7 +607,9 @@ describe('ProjectSessionView.vue', () => {
             `api/events/networkRequest/byRequestId/${requestEvent.eventable.request_id}/logs**`
           ).as('fetchLogs')
 
-          cy.visit(`projects/${project.id}/sessions/${sessionWithConvertedVideo.id}`)
+          cy.visit(
+            `company/${companyId}/projects/${project.id}/sessions/${sessionWithConvertedVideo.id}`
+          )
 
           cy.wait(['@fetchSession', '@fetchSessionEvents'])
 

--- a/apps/webapp/cypress/e2e/views/projects/ProjectSessionsView.vue.spec.ts
+++ b/apps/webapp/cypress/e2e/views/projects/ProjectSessionsView.vue.spec.ts
@@ -36,7 +36,7 @@ describe('ProjectSessionsView.vue', () => {
   it('should display correct number sessions', () => {
     cy.intercept('GET', `**/api/projects/${project.id}/sessions**`).as('fetchSessionRequest')
 
-    cy.visit(`projects/${project.id}/sessions`)
+    cy.visit(`company/${companyId}/projects/${project.id}/sessions`)
 
     cy.wait('@fetchSessionRequest').then(({ request, response }) => {
       expect(request.url).to.include('createdAtOrder=desc')
@@ -66,7 +66,7 @@ describe('ProjectSessionsView.vue', () => {
 
       const searchCreatedBy = loggedUser.first_name
 
-      cy.visit(`projects/${project.id}/sessions`)
+      cy.visit(`company/${companyId}/projects/${project.id}/sessions`)
 
       cy.wait('@fetchSessionRequest')
 
@@ -91,7 +91,7 @@ describe('ProjectSessionsView.vue', () => {
       const os = sessions[0].os
       const sessionsWithOS = sessions.filter((s) => s.os === os)
 
-      cy.visit(`projects/${project.id}/sessions`)
+      cy.visit(`company/${companyId}/projects/${project.id}/sessions`)
 
       cy.wait('@fetchSessionRequest')
 
@@ -116,7 +116,7 @@ describe('ProjectSessionsView.vue', () => {
       const platform = sessions[0].platform_name
       const sessionsWithPlatform = sessions.filter((s) => s.platform_name === platform)
 
-      cy.visit(`projects/${project.id}/sessions`)
+      cy.visit(`company/${companyId}/projects/${project.id}/sessions`)
 
       cy.wait('@fetchSessionRequest')
 
@@ -141,7 +141,7 @@ describe('ProjectSessionsView.vue', () => {
       const version = sessions[0].version
       const sessionsWithVersion = sessions.filter((s) => s.version === version)
 
-      cy.visit(`projects/${project.id}/sessions`)
+      cy.visit(`company/${companyId}/projects/${project.id}/sessions`)
 
       cy.wait('@fetchSessionRequest')
 
@@ -165,7 +165,7 @@ describe('ProjectSessionsView.vue', () => {
     it('should make request when changing pages', () => {
       cy.intercept('GET', `**/api/projects/${project.id}/sessions**`).as('fetchSessionRequest')
 
-      cy.visit(`projects/${project.id}/sessions`)
+      cy.visit(`company/${companyId}/projects/${project.id}/sessions`)
 
       cy.wait('@fetchSessionRequest')
 

--- a/apps/webapp/cypress/e2e/views/projects/ProjectSettingsView.vue.spec.ts
+++ b/apps/webapp/cypress/e2e/views/projects/ProjectSettingsView.vue.spec.ts
@@ -25,7 +25,7 @@ describe('ProjectSettingsView.vue', () => {
     it('should display correct project name', () => {
       cy.intercept('GET', `**/api/projects/${project.id}`).as('fetchProject')
 
-      cy.visit(`projects/${project.id}/settings`)
+      cy.visit(`company/${companyId}/projects/${project.id}/settings`)
 
       cy.wait('@fetchProject')
 
@@ -35,7 +35,7 @@ describe('ProjectSettingsView.vue', () => {
     it('should display correct project key', () => {
       cy.intercept('GET', `**/api/projects/${project.id}`).as('fetchProject')
 
-      cy.visit(`projects/${project.id}/settings`)
+      cy.visit(`company/${companyId}/projects/${project.id}/settings`)
 
       cy.wait('@fetchProject')
 
@@ -45,7 +45,7 @@ describe('ProjectSettingsView.vue', () => {
     it('should have link to docs on `project key` section', () => {
       cy.intercept('GET', `**/api/projects/${project.id}`).as('fetchProject')
 
-      cy.visit(`projects/${project.id}/settings`)
+      cy.visit(`company/${companyId}/projects/${project.id}/settings`)
 
       cy.wait('@fetchProject')
 
@@ -57,7 +57,7 @@ describe('ProjectSettingsView.vue', () => {
     it("should allow user to copy project's key", () => {
       cy.intercept('GET', `**/api/projects/${project.id}`).as('fetchProject')
 
-      cy.visit(`projects/${project.id}/settings`)
+      cy.visit(`company/${companyId}/projects/${project.id}/settings`)
 
       cy.wait('@fetchProject')
 
@@ -73,7 +73,7 @@ describe('ProjectSettingsView.vue', () => {
     it('should display warning saying security token is private', () => {
       cy.intercept('GET', `**/api/projects/${project.id}`).as('fetchProject')
 
-      cy.visit(`projects/${project.id}/settings`)
+      cy.visit(`company/${companyId}/projects/${project.id}/settings`)
 
       cy.wait('@fetchProject')
 
@@ -83,7 +83,7 @@ describe('ProjectSettingsView.vue', () => {
     it('should display correct information for security token', () => {
       cy.intercept('GET', `**/api/projects/${project.id}`).as('fetchProject')
 
-      cy.visit(`projects/${project.id}/settings`)
+      cy.visit(`company/${companyId}/projects/${project.id}/settings`)
 
       cy.wait('@fetchProject')
 
@@ -95,7 +95,7 @@ describe('ProjectSettingsView.vue', () => {
     it('should allow to copy security token', () => {
       cy.intercept('GET', `**/api/projects/${project.id}`).as('fetchProject')
 
-      cy.visit(`projects/${project.id}/settings`)
+      cy.visit(`company/${companyId}/projects/${project.id}/settings`)
 
       cy.wait('@fetchProject')
 
@@ -110,7 +110,7 @@ describe('ProjectSettingsView.vue', () => {
       cy.intercept('GET', `**/api/projects/${project.id}`).as('fetchProject')
       cy.intercept('PUT', `**/api/projects/${project.id}/securityToken`).as('updateSecurityToken')
 
-      cy.visit(`projects/${project.id}/settings`)
+      cy.visit(`company/${companyId}/projects/${project.id}/settings`)
 
       cy.wait('@fetchProject')
 
@@ -131,7 +131,7 @@ describe('ProjectSettingsView.vue', () => {
     it('should allow user to cancel updating security token', () => {
       cy.intercept('GET', `**/api/projects/${project.id}`).as('fetchProject')
 
-      cy.visit(`projects/${project.id}/settings`)
+      cy.visit(`company/${companyId}/projects/${project.id}/settings`)
 
       cy.wait('@fetchProject')
 

--- a/apps/webapp/src/App.vue
+++ b/apps/webapp/src/App.vue
@@ -15,16 +15,28 @@
 </template>
 
 <script setup lang="ts">
-import { RouterView } from 'vue-router'
+import { RouterView, useRoute } from 'vue-router'
 import { useAppStore } from '@/stores/app'
 import { onBeforeMount, ref } from 'vue'
 
 const isLoading = ref(true)
+
 const appStore = useAppStore()
+
+const route = useRoute()
 
 onBeforeMount(async () => {
   isLoading.value = true
   await appStore.onLoadApp()
+
+  if (route.params.companyId) {
+    appStore.activeCompany = appStore.loggedUserCompanies.data.find(
+      (c) => c.id === route.params.companyId
+    )!
+  } else {
+    appStore.activeCompany = appStore.loggedUserCompanies.data[0]
+  }
+
   isLoading.value = false
 })
 </script>

--- a/apps/webapp/src/layouts/NavigationLayout.vue
+++ b/apps/webapp/src/layouts/NavigationLayout.vue
@@ -82,7 +82,7 @@
               <li>
                 <router-link
                   active-class="bg-white shadow-lg"
-                  :to="{ name: 'listProjects' }"
+                  :to="{ name: 'listProjects', params: { companyId: appStore.activeCompany!.id } }"
                   class="flex items-center cursor-pointer p-4 rounded-md text-slate-500 transition-all"
                 >
                   <i class="pi pi-server mr-2 bg-white p-2.5 rounded-md text-slate-800"></i>
@@ -92,7 +92,7 @@
               <li>
                 <router-link
                   active-class="bg-white shadow-lg"
-                  :to="{ name: 'projectCreate' }"
+                  :to="{ name: 'projectCreate', params: { companyId: appStore.activeCompany!.id } }"
                   class="flex items-center cursor-pointer p-4 rounded-md text-slate-500 transition-all"
                 >
                   <i class="pi pi-plus mr-2 bg-white p-2.5 rounded-md text-slate-800"></i>
@@ -225,6 +225,6 @@ function onToggleCompaniesMenu(event: Event) {
 function setActiveCompany(company: CompanyCodec) {
   appStore.activeCompany = company
 
-  router.push({ name: 'listProjects' })
+  router.push({ name: 'listProjects', params: { companyId: company.id } })
 }
 </script>

--- a/apps/webapp/src/layouts/ProjectLayout.vue
+++ b/apps/webapp/src/layouts/ProjectLayout.vue
@@ -106,7 +106,7 @@ const projectNavigationItems = computed(() => [
     icon: 'pi pi-fw pi-home',
     to: {
       name: 'projectDashboard',
-      params: { projectId: projectStore.activeProject?.id }
+      params: { projectId: projectStore.activeProject?.id, companyId: route.params.companyId }
     }
   },
   {
@@ -114,7 +114,7 @@ const projectNavigationItems = computed(() => [
     icon: 'pi pi-fw pi-video',
     to: {
       name: 'projectSessions',
-      params: { projectId: projectStore.activeProject?.id }
+      params: { projectId: projectStore.activeProject?.id, companyId: route.params.companyId }
     }
   },
   {
@@ -122,7 +122,7 @@ const projectNavigationItems = computed(() => [
     icon: 'pi pi-fw pi-cog',
     to: {
       name: 'projectSettings',
-      params: { projectId: projectStore.activeProject?.id }
+      params: { projectId: projectStore.activeProject?.id, companyId: route.params.companyId }
     }
   }
 ])

--- a/apps/webapp/src/router/children/projectRoutes.ts
+++ b/apps/webapp/src/router/children/projectRoutes.ts
@@ -2,7 +2,7 @@ import type { RouteRecordRaw } from 'vue-router'
 
 export const projectRoutes: RouteRecordRaw[] = [
   {
-    path: '/projects',
+    path: 'company/:companyId/projects',
     name: 'listProjects',
     component: () => import('@/views/projects/ListProjectsView.vue'),
     meta: {
@@ -14,7 +14,7 @@ export const projectRoutes: RouteRecordRaw[] = [
     component: () => import('@/layouts/ProjectLayout.vue'),
     children: [
       {
-        path: '/projects/:projectId/dashboard',
+        path: '/company/:companyId/projects/:projectId/dashboard',
         name: 'projectDashboard',
         component: () => import('@/views/projects/ProjectDashboard.vue'),
         meta: {
@@ -22,7 +22,7 @@ export const projectRoutes: RouteRecordRaw[] = [
         }
       },
       {
-        path: '/projects/:projectId/sessions',
+        path: '/company/:companyId/projects/:projectId/sessions',
         name: 'projectSessions',
         component: () => import('@/views/projects/ProjectSessionsView.vue'),
         meta: {
@@ -30,7 +30,7 @@ export const projectRoutes: RouteRecordRaw[] = [
         }
       },
       {
-        path: '/projects/:projectId/sessions/:sessionId',
+        path: '/company/:companyId/projects/:projectId/sessions/:sessionId',
         name: 'projectSession',
         component: () => import('@/views/projects/ProjectSessionView.vue'),
         meta: {
@@ -38,7 +38,7 @@ export const projectRoutes: RouteRecordRaw[] = [
         }
       },
       {
-        path: '/projects/:projectId/settings',
+        path: '/company/:companyId/projects/:projectId/settings',
         name: 'projectSettings',
         component: () => import('@/views/projects/ProjectSettingsView.vue'),
         meta: {
@@ -49,7 +49,7 @@ export const projectRoutes: RouteRecordRaw[] = [
   },
 
   {
-    path: '/projects/create',
+    path: 'company/:companyId/projects/create',
     name: 'projectCreate',
     component: () => import('@/views/projects/CreateProjectView.vue'),
     meta: {

--- a/apps/webapp/src/router/index.ts
+++ b/apps/webapp/src/router/index.ts
@@ -11,7 +11,10 @@ const router = createRouter({
   routes: [
     {
       path: '/',
-      redirect: { name: 'listProjects' }
+      component: () => import('@/views/RootView.vue'),
+      meta: {
+        requiresAuth: true
+      }
     },
     {
       path: '/',

--- a/apps/webapp/src/services/api/resources/project/codec.ts
+++ b/apps/webapp/src/services/api/resources/project/codec.ts
@@ -1,6 +1,7 @@
 import type { DateTime, PaginationParameters, ResourceID } from '@/services/api'
 import type { UserCodec } from '@/services/api/resources/user/codec'
 import { OrderBy } from '@/services/api'
+import type { CompanyCodec } from '@/services/api/resources/company/codec'
 
 export interface ProjectCodec {
   id: ResourceID
@@ -9,6 +10,7 @@ export interface ProjectCodec {
   securityToken: string
   createdBy?: UserCodec
   createdAt: DateTime
+  company?: CompanyCodec
 }
 
 export type CreateProjectBody = { title: string }

--- a/apps/webapp/src/stores/app.ts
+++ b/apps/webapp/src/stores/app.ts
@@ -65,8 +65,6 @@ export const useAppStore = defineStore('appStore', {
       const { data } = await getLoggedUserCompanies(userId, params)
 
       this.loggedUserCompanies = data
-
-      this.activeCompany = data.data[0] as CompanyCodec
     },
 
     async onLoadApp() {

--- a/apps/webapp/src/views/RootView.vue
+++ b/apps/webapp/src/views/RootView.vue
@@ -1,0 +1,25 @@
+<template>
+  <div class="h-screen w-screen grid justify-center items-center">
+    <ProgressSpinner />
+  </div>
+</template>
+<script lang="ts" setup>
+import { onMounted } from 'vue'
+import { useAppStore } from '@/stores/app'
+import { useRouter } from 'vue-router'
+
+const appStore = useAppStore()
+
+const router = useRouter()
+
+// This function will only run if the user is logged in
+// We check if the user is logged in, in the route guards in `router/index.ts`
+async function redirectToCompany() {
+  await router.push({
+    name: 'listProjects',
+    params: { companyId: appStore.loggedUserCompanies.data[0].id }
+  })
+}
+
+onMounted(redirectToCompany)
+</script>

--- a/apps/webapp/src/views/auth/FinishRegistrationView.vue
+++ b/apps/webapp/src/views/auth/FinishRegistrationView.vue
@@ -157,6 +157,7 @@ import type { WrappedResponse } from '@/services/api/axios'
 import { useToast } from 'primevue/usetoast'
 import { HttpStatusCode } from 'axios'
 import { useAppStore } from '@/stores/app'
+import type { CompanyCodec } from '@/services/api/resources/company/codec'
 
 const isCreatingUser = ref(false)
 
@@ -211,6 +212,10 @@ const onSubmit = getSubmitFn(validationSchema, async (values) => {
       tokenName: createTokenName()
     })
 
+    const activeCompany: CompanyCodec = appStore.loggedUserCompanies.data[0] as CompanyCodec
+
+    appStore.activeCompany = activeCompany
+
     if (route.query.redirectTo) {
       await router.push(route.query.redirectTo as string)
     } else if (data.data.registerToken.hasOnboarding) {
@@ -219,7 +224,10 @@ const onSubmit = getSubmitFn(validationSchema, async (values) => {
           '`data.company.id` and `data.project.id` should be present in the response. Skipping onboarding.'
         )
 
-        await router.push({ name: 'listProjects' })
+        await router.push({
+          name: 'listProjects',
+          params: { companyId: appStore.loggedUserCompanies.data[0]!.id }
+        })
 
         return
       }
@@ -229,7 +237,10 @@ const onSubmit = getSubmitFn(validationSchema, async (values) => {
         params: { projectId: data.data.project?.id, companyId: data.data.company?.id }
       })
     } else {
-      await router.push({ name: 'listProjects' })
+      await router.push({
+        name: 'listProjects',
+        params: { companyId: activeCompany.id }
+      })
     }
   } catch (e) {
     if (isError(e as WrappedResponse, HttpStatusCode.NotFound)) {

--- a/apps/webapp/src/views/auth/LoginView.vue
+++ b/apps/webapp/src/views/auth/LoginView.vue
@@ -126,6 +126,7 @@ import { useToast } from 'primevue/usetoast'
 import { displayGeneralError } from '@/services/ui'
 import { useAppStore } from '@/stores/app'
 import { useRoute, useRouter } from 'vue-router'
+import type { CompanyCodec } from '@/services/api/resources/company/codec'
 
 const isLoggingIn = ref(false)
 
@@ -152,10 +153,14 @@ const onSubmit = getSubmitFn(validationSchema, async (values) => {
 
     await appStore.loginUser({ ...values, ...initialValues })
 
+    const activeCompany = appStore.loggedUserCompanies.data[0] as CompanyCodec
+
+    appStore.activeCompany = activeCompany
+
     if (route.query.redirectTo) {
       await router.push(route.query.redirectTo as string)
     } else {
-      await router.push({ name: 'listProjects' })
+      await router.push({ name: 'listProjects', params: { companyId: activeCompany.id } })
     }
   } catch (e) {
     if (isError(e as WrappedResponse, HttpStatusCode.Forbidden)) {

--- a/apps/webapp/src/views/companies/CreateCompanyView.vue
+++ b/apps/webapp/src/views/companies/CreateCompanyView.vue
@@ -84,7 +84,7 @@ const onSubmit = getSubmitFn(validationSchema, async (values) => {
     appStore.activeCompany = data.data
     appStore.loggedUserCompanies.data.push(data.data)
 
-    await router.push({ name: 'listProjects' })
+    await router.push({ name: 'listProjects', params: { companyId: appStore.activeCompany!.id } })
   } catch (e) {
     displayGeneralError(e as WrappedResponse)
   } finally {

--- a/apps/webapp/src/views/onboarding/OnboardingInviteTeamMembersView.vue
+++ b/apps/webapp/src/views/onboarding/OnboardingInviteTeamMembersView.vue
@@ -97,7 +97,10 @@
 
       <div class="flex justify-between !mt-4">
         <RouterLink
-          :to="{ name: 'projectDashboard', params: { projectId: route.params.projectId } }"
+          :to="{
+            name: 'projectDashboard',
+            params: { projectId: route.params.projectId, companyId: route.params.companyId }
+          }"
           data-cy="onboarding-invite-page__skip-step"
         >
           <Button
@@ -147,7 +150,7 @@ async function onFinishOnboarding() {
 
     await router.push({
       name: 'projectDashboard',
-      params: { projectId: route.params.projectId }
+      params: { projectId: route.params.projectId, companyId: route.params.companyId as string }
     })
   } catch (e) {
     toast.add({

--- a/apps/webapp/src/views/projects/CreateProjectView.vue
+++ b/apps/webapp/src/views/projects/CreateProjectView.vue
@@ -86,7 +86,10 @@ const onSubmit = getSubmitFn(validationSchema, async (values) => {
 
     const { data } = await projectStore.createProject(appStore.activeCompany.id, values)
 
-    await router.push({ name: 'projectDashboard', params: { projectId: data.data.id } })
+    await router.push({
+      name: 'projectDashboard',
+      params: { projectId: data.data.id, companyId: appStore.activeCompany!.id }
+    })
   } catch (e) {
     displayGeneralError(e as WrappedResponse, { group: 'bottom-center' })
   } finally {

--- a/apps/webapp/src/views/projects/ListProjectsView.vue
+++ b/apps/webapp/src/views/projects/ListProjectsView.vue
@@ -45,7 +45,7 @@
             <router-link
               data-cy="list-projects-view__project-dashboard"
               :data-project-id="data.id"
-              :to="{ name: 'projectDashboard', params: { projectId: data.id } }"
+              :to="{ name: 'projectDashboard', params: { projectId: data.id, companyId: appStore.activeCompany!.id } }"
             >
               <Button
                 v-tooltip.left="'Dashboard'"
@@ -59,7 +59,7 @@
             <router-link
               data-cy="list-projects-view__project-sessions"
               :data-project-id="data.id"
-              :to="{ name: 'projectSessions', params: { projectId: data.id } }"
+              :to="{ name: 'projectSessions', params: { projectId: data.id, companyId: appStore.activeCompany!.id } }"
             >
               <Button
                 v-tooltip.left="'Sessions'"

--- a/apps/webapp/src/views/sessions/AssignSessionCurrentlyLoggedUserView.vue
+++ b/apps/webapp/src/views/sessions/AssignSessionCurrentlyLoggedUserView.vue
@@ -80,6 +80,14 @@ const isFetchingSessionInformation = ref(true)
 async function assignSessionToLoggedUser() {
   if (!appStore.isAuthenticated) return
 
+  if (!session.value.project) {
+    throw new Error('`session.value.project` should be defined')
+  }
+
+  if (!session.value.project.company) {
+    throw new Error('`session.value.project.company` should be defined')
+  }
+
   try {
     isAssigningSessionToUser.value = true
 
@@ -90,8 +98,9 @@ async function assignSessionToLoggedUser() {
     await router.push({
       name: 'projectSession',
       params: {
-        projectId: response.data.data.project!.id,
-        sessionId: route.params.sessionId as string
+        projectId: response.data.data.project.id,
+        sessionId: route.params.sessionId as string,
+        companyId: session.value.project.company.id
       }
     })
   } catch (e) {
@@ -130,11 +139,16 @@ function copySessionUrl() {
     throw new Error('`session.value.project` should be defined')
   }
 
+  if (!session.value.project.company) {
+    throw new Error('`session.value.project.company` should be defined')
+  }
+
   const url = router.resolve({
     name: 'projectSession',
     params: {
       projectId: session.value.project.id,
-      sessionId: route.params.sessionId as string
+      sessionId: route.params.sessionId as string,
+      companyId: session.value.project.company.id
     }
   })
 

--- a/apps/webapp/src/views/sessions/AssignSessionCurrentlyLoggedUserView.vue
+++ b/apps/webapp/src/views/sessions/AssignSessionCurrentlyLoggedUserView.vue
@@ -98,7 +98,7 @@ async function assignSessionToLoggedUser() {
     await router.push({
       name: 'projectSession',
       params: {
-        projectId: response.data.data.project.id,
+        projectId: response.data.data.project!.id,
         sessionId: route.params.sessionId as string,
         companyId: session.value.project.company.id
       }


### PR DESCRIPTION
### 🔖 Feature description

Whenever I select a company in the webapp and refresh the page, the company is not selected.

We should be able to select the URL and land on the correct company.

The company should be selected.

![image](https://github.com/devqaly/devqaly/assets/17223411/61cef04f-ee73-4282-b304-f5cfdbed7bda)

The "devqaly" company is selected but nothing is being shown in the URL.

### 🎤 Why is this feature needed ?

We need to be able to share this with team mates and have it select the correct company.

### ✌️ How do you aim to achieve this?

Have the URL reflect the company's ID: `https://staging-app.devqaly.com/company/{id}/projects`

This should reflect for sessions as well: `https://staging-app.devqaly.com/company/{id}/projects/{projectId}/sessions/{sessionId}`

This will have effects on the SDK. We will need to modify the SDK to have the id of the company when creating a session. We wanted to work on this feature before but since it would affect the SDK JS we postponed it.

### 🔄️ Additional Information

_No response_

### 👀 Have you spent some time to check if this feature request has been raised before?

- [X] I checked and didn't find similar issue

### Are you willing to submit PR?

Yes I am willing to submit a PR!